### PR TITLE
fix: Add security group rule to allow external traffic through the NLB

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Terraform module which deploys a 3-node Vault Enterprise cluster on AWS with Raf
 - 3 Vault nodes across separate availability zones, each with a dedicated EBS volume for Raft storage
 - AWS KMS auto-unseal
 - Raft auto-join via EC2 tag discovery
-- Internal NLB with TCP passthrough (TLS terminates on the Vault nodes)
+- NLB with TCP passthrough (TLS terminates on the Vault nodes), internal by default
 - Route 53 DNS alias to the NLB
 - TLS certificates and license stored in AWS Secrets Manager
 - Bastion host for SSH access to the private Vault nodes
@@ -40,6 +40,28 @@ export VAULT_ADDR="https://vault.<your-domain>:8200"
 export VAULT_CACERT=vault-ca.crt
 vault status
 ```
+## Network access
+
+By default, the NLB is internal and the Vault API is only reachable from within
+the VPC. Access the cluster through the bastion host or a VPN connection.
+
+To expose the Vault UI and API over the public internet, set `nlb_internal` to
+`false` and provide the CIDR blocks that should be allowed to reach port 8200:
+
+```hcl
+module "vault" {
+  # ...
+
+  nlb_internal            = false
+  vault_api_allowed_cidrs = ["0.0.0.0/0"]
+}
+```
+
+This places the NLB in the public subnets and adds security group rules for the
+specified CIDRs. The Vault nodes remain in private subnets — only the NLB is
+internet-facing. Restrict `vault_api_allowed_cidrs` to known ranges where
+possible.
+
 ## Security considerations
 
 The Terraform `tls` provider stores private key material (CA and server keys) in
@@ -109,6 +131,7 @@ module "vault" {
 | <a name="input_nlb_internal"></a> [nlb\_internal](#input\_nlb\_internal) | Whether the NLB is internal. | `bool` | `true` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Name prefix for all resources. | `string` | n/a | yes |
 | <a name="input_route53_zone_name"></a> [route53\_zone\_name](#input\_route53\_zone\_name) | Name of the existing Route 53 hosted zone. | `string` | n/a | yes |
+| <a name="input_vault_api_allowed_cidrs"></a> [vault\_api\_allowed\_cidrs](#input\_vault\_api\_allowed\_cidrs) | CIDR blocks allowed to reach the Vault API (port 8200) from outside the VPC. Only effective when nlb\_internal is false. | `list(string)` | `[]` | no |
 | <a name="input_vault_ebs_volume_size"></a> [vault\_ebs\_volume\_size](#input\_vault\_ebs\_volume\_size) | Size in GiB of the EBS volume for Vault Raft storage. | `number` | `100` | no |
 | <a name="input_vault_instance_type"></a> [vault\_instance\_type](#input\_vault\_instance\_type) | EC2 instance type for Vault nodes. | `string` | `"m5.large"` | no |
 | <a name="input_vault_license"></a> [vault\_license](#input\_vault\_license) | Vault Enterprise license string. | `string` | n/a | yes |
@@ -163,6 +186,7 @@ module "vault" {
 | [aws_vpc_security_group_egress_rule.vault_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_egress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.bastion_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.vault_api](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
+| [aws_vpc_security_group_ingress_rule.vault_api_external](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.vault_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.vault_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.vpc_endpoints_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |

--- a/variables.tf
+++ b/variables.tf
@@ -111,3 +111,9 @@ variable "nlb_internal" {
   description = "Whether the NLB is internal."
   default     = true
 }
+
+variable "vault_api_allowed_cidrs" {
+  type        = list(string)
+  description = "CIDR blocks allowed to reach the Vault API (port 8200) from outside the VPC. Only effective when nlb_internal is false."
+  default     = []
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -115,6 +115,17 @@ resource "aws_vpc_security_group_ingress_rule" "vault_api" {
   cidr_ipv4         = var.vpc_cidr
 }
 
+resource "aws_vpc_security_group_ingress_rule" "vault_api_external" {
+  for_each = toset(var.vault_api_allowed_cidrs)
+
+  security_group_id = aws_security_group.vault.id
+  description       = "Vault API from external CIDR"
+  from_port         = 8200
+  to_port           = 8200
+  ip_protocol       = "tcp"
+  cidr_ipv4         = each.value
+}
+
 resource "aws_vpc_security_group_ingress_rule" "vault_cluster" {
   security_group_id            = aws_security_group.vault.id
   description                  = "Vault cluster traffic"


### PR DESCRIPTION
Setting nlb_internal to false made the NLB internet-facing but the Vault security group only allowed port 8200 ingress from the VPC CIDR, so external traffic was silently dropped.

Add a vault_api_allowed_cidrs variable and a corresponding security group ingress rule to allow configurable external access on port 8200.