### PR TITLE
fix: Replace deprecated aws_region name attribute with region

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,5 +1,5 @@
 resource "aws_s3_bucket" "vault_snapshots" {
-  bucket = "${var.project_name}-vault-snapshots-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}-an"
+  bucket = "${var.project_name}-vault-snapshots-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.region}-an"
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault-snapshots" })
 }


### PR DESCRIPTION
- Replace `data.aws_region.current.name` with `data.aws_region.current.region` in S3 bucket naming
- The `name` attribute is deprecated in AWS provider v6, consistent with existing usage in vpc.tf and ec2.tf