### PR TITLE
fix: Add length validation to project_name for S3 bucket name limit

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,11 @@
 variable "project_name" {
   type        = string
   description = "Name prefix for all resources."
+
+  validation {
+    condition     = length(var.project_name) <= 16
+    error_message = "Must be 16 characters or fewer to fit within the 63-character S3 bucket name limit."
+  }
 }
 
 variable "route53_zone" {


### PR DESCRIPTION
- Validate project_name is 16 characters or fewer
- The S3 bucket naming template appends up to 47 characters (`-vault-snapshots-{account_id}-{region}-an`), and S3 bucket names are limited to 63 characters