### PR TITLE
fix: Add bucket_namespace for account-regional S3 naming

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,5 +1,6 @@
 resource "aws_s3_bucket" "vault_snapshots" {
-  bucket = "${var.project_name}-vault-snapshots-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.region}-an"
+  bucket           = "${var.project_name}-vault-snapshots-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.region}-an"
+  bucket_namespace = "account-regional"
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault-snapshots" })
 }


### PR DESCRIPTION
- Add `bucket_namespace = "account-regional"` to the S3 bucket resource
- Required by AWS provider v6.37.0 which validates S3 bucket names and rejects the account-regional namespace pattern without this argument