### PR TITLE
chore: Add force_destroy to S3 snapshot bucket

### DIFF
--- a/s3.tf
+++ b/s3.tf
@@ -1,6 +1,7 @@
 resource "aws_s3_bucket" "vault_snapshots" {
   bucket           = "${var.project_name}-vault-snapshots-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.region}-an"
   bucket_namespace = "account-regional"
+  force_destroy    = true
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault-snapshots" })
 }


### PR DESCRIPTION
- Add `force_destroy = true` so `terraform destroy` can remove the bucket when it contains snapshots