### PR TITLE
feat: Add existing_vpc support for shared VPC deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ module "vault" {
 | <a name="input_common_tags"></a> [common\_tags](#input\_common\_tags) | Tags to apply to all resources. | `map(string)` | `{}` | no |
 | <a name="input_ec2_ami"></a> [ec2\_ami](#input\_ec2\_ami) | AMI to use for EC2 instances. Must be Ubuntu or Debian-based. | <pre>object({<br/>    id   = string<br/>    name = string<br/>  })</pre> | n/a | yes |
 | <a name="input_ec2_key_pair_name"></a> [ec2\_key\_pair\_name](#input\_ec2\_key\_pair\_name) | Name of an existing EC2 key pair for SSH access. | `string` | n/a | yes |
+| <a name="input_existing_vpc"></a> [existing\_vpc](#input\_existing\_vpc) | Existing VPC to deploy into. When null (default), a new VPC is created.<br/>The existing VPC must already have the required VPC endpoints:<br/>Secrets Manager, KMS, and EC2 (Interface), S3 (Gateway). | <pre>object({<br/>    vpc_id             = string<br/>    private_subnet_ids = list(string)<br/>    public_subnet_ids  = list(string)<br/>  })</pre> | `null` | no |
 | <a name="input_nlb_internal"></a> [nlb\_internal](#input\_nlb\_internal) | Whether the NLB is internal. | `bool` | `true` | no |
 | <a name="input_project_name"></a> [project\_name](#input\_project\_name) | Name prefix for all resources. | `string` | n/a | yes |
 | <a name="input_route53_zone"></a> [route53\_zone](#input\_route53\_zone) | Route 53 hosted zone for the Vault DNS record. | <pre>object({<br/>    zone_id = string<br/>    name    = string<br/>  })</pre> | n/a | yes |
@@ -208,6 +209,7 @@ module "vault" {
 | [aws_iam_policy_document.vault_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_snapshots](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_vpc.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 
 ## Outputs
 

--- a/ec2.tf
+++ b/ec2.tf
@@ -4,7 +4,7 @@ resource "aws_instance" "bastion" {
   ami                         = var.ec2_ami.id
   instance_type               = var.bastion_instance_type
   key_name                    = var.ec2_key_pair_name
-  subnet_id                   = module.vpc.public_subnets[0]
+  subnet_id                   = local.vpc.public_subnet_ids[0]
   vpc_security_group_ids      = [aws_security_group.bastion.id]
   associate_public_ip_address = true
 
@@ -25,7 +25,7 @@ resource "aws_instance" "vault" {
   ami                    = var.ec2_ami.id
   instance_type          = var.vault_instance_type
   key_name               = var.ec2_key_pair_name
-  subnet_id              = module.vpc.private_subnets[count.index]
+  subnet_id              = local.vpc.private_subnet_ids[count.index]
   vpc_security_group_ids = [aws_security_group.vault.id]
   iam_instance_profile   = aws_iam_instance_profile.vault.name
 

--- a/examples/basic/defaults.auto.tfvars.example
+++ b/examples/basic/defaults.auto.tfvars.example
@@ -1,0 +1,9 @@
+project_name      = "vault"
+route53_zone_name = "example.com"
+vault_license     = "your-vault-enterprise-license-here"
+ec2_key_pair_name = "my-key-pair"
+ec2_ami_owner     = "123456789012"
+ec2_ami_name      = "hc-base-ubuntu-2404-amd64-*"
+
+nlb_internal            = false
+vault_api_allowed_cidrs = ["0.0.0.0/0"]

--- a/examples/existing-vpc/README.md
+++ b/examples/existing-vpc/README.md
@@ -1,0 +1,67 @@
+# Example - Existing VPC
+
+This example deploys Vault Enterprise into a pre-existing VPC, discovered by its Name tag. The existing VPC must already have the required VPC endpoints: Secrets Manager, KMS, and EC2 (Interface), S3 (Gateway).
+
+```hcl
+data "aws_vpc" "selected" {
+  filter {
+    name   = "tag:Name"
+    values = [var.vpc_name]
+  }
+}
+
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.selected.id]
+  }
+  filter {
+    name   = "tag:Name"
+    values = ["${var.vpc_name}-private-*"]
+  }
+}
+
+data "aws_subnets" "public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.selected.id]
+  }
+  filter {
+    name   = "tag:Name"
+    values = ["${var.vpc_name}-public-*"]
+  }
+}
+
+data "aws_route53_zone" "selected" {
+  name = var.route53_zone_name
+}
+
+data "aws_ami" "selected" {
+  most_recent = true
+  owners      = [var.ec2_ami_owner]
+
+  filter {
+    name   = "name"
+    values = [var.ec2_ami_name]
+  }
+}
+
+module "vault" {
+  source = "git::https://github.com/craigsloggett/terraform-aws-vault-enterprise"
+
+  project_name      = var.project_name
+  route53_zone      = data.aws_route53_zone.selected
+  vault_license     = var.vault_license
+  ec2_key_pair_name = var.ec2_key_pair_name
+  ec2_ami           = data.aws_ami.selected
+
+  nlb_internal            = var.nlb_internal
+  vault_api_allowed_cidrs = var.vault_api_allowed_cidrs
+
+  existing_vpc = {
+    vpc_id             = data.aws_vpc.selected.id
+    private_subnet_ids = data.aws_subnets.private.ids
+    public_subnet_ids  = data.aws_subnets.public.ids
+  }
+}
+```

--- a/examples/existing-vpc/defaults.auto.tfvars.example
+++ b/examples/existing-vpc/defaults.auto.tfvars.example
@@ -1,0 +1,10 @@
+project_name      = "vault"
+vpc_name          = "hashistack"
+route53_zone_name = "example.com"
+vault_license     = "your-vault-enterprise-license-here"
+ec2_key_pair_name = "my-key-pair"
+ec2_ami_owner     = "123456789012"
+ec2_ami_name      = "hc-base-ubuntu-2404-amd64-*"
+
+nlb_internal            = false
+vault_api_allowed_cidrs = ["0.0.0.0/0"]

--- a/examples/existing-vpc/main.tf
+++ b/examples/existing-vpc/main.tf
@@ -1,0 +1,62 @@
+data "aws_vpc" "selected" {
+  filter {
+    name   = "tag:Name"
+    values = [var.vpc_name]
+  }
+}
+
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.selected.id]
+  }
+  filter {
+    name   = "tag:Name"
+    values = ["${var.vpc_name}-private-*"]
+  }
+}
+
+data "aws_subnets" "public" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.selected.id]
+  }
+  filter {
+    name   = "tag:Name"
+    values = ["${var.vpc_name}-public-*"]
+  }
+}
+
+data "aws_route53_zone" "selected" {
+  name = var.route53_zone_name
+}
+
+data "aws_ami" "selected" {
+  most_recent = true
+  owners      = [var.ec2_ami_owner]
+
+  filter {
+    name   = "name"
+    values = [var.ec2_ami_name]
+  }
+}
+
+module "vault" {
+  # tflint-ignore: terraform_module_pinned_source
+  source = "git::https://github.com/craigsloggett/terraform-aws-vault-enterprise"
+
+  project_name      = var.project_name
+  route53_zone      = data.aws_route53_zone.selected
+  vault_license     = var.vault_license
+  ec2_key_pair_name = var.ec2_key_pair_name
+  ec2_ami           = data.aws_ami.selected
+
+  nlb_internal            = var.nlb_internal
+  vault_api_allowed_cidrs = var.vault_api_allowed_cidrs
+
+  existing_vpc = {
+    vpc_id             = data.aws_vpc.selected.id
+    private_subnet_ids = data.aws_subnets.private.ids
+    public_subnet_ids  = data.aws_subnets.public.ids
+  }
+}

--- a/examples/existing-vpc/outputs.tf
+++ b/examples/existing-vpc/outputs.tf
@@ -1,0 +1,35 @@
+output "vault_url" {
+  description = "URL of the Vault cluster."
+  value       = module.vault.vault_url
+}
+
+output "bastion_public_ip" {
+  description = "Public IP of the bastion host."
+  value       = module.vault.bastion_public_ip
+}
+
+output "vault_private_ips" {
+  description = "Private IPs of the Vault nodes."
+  value       = module.vault.vault_private_ips
+}
+
+output "vault_target_group_arn" {
+  description = "ARN of the Vault NLB target group."
+  value       = module.vault.vault_target_group_arn
+}
+
+output "ec2_ami_name" {
+  description = "Name of the AMI used for EC2 instances."
+  value       = module.vault.ec2_ami_name
+}
+
+output "vault_snapshot_bucket" {
+  description = "S3 bucket for Vault snapshots."
+  value       = module.vault.vault_snapshot_bucket
+}
+
+output "vault_ca_cert" {
+  description = "CA certificate for trusting the Vault TLS chain."
+  value       = module.vault.vault_ca_cert
+  sensitive   = true
+}

--- a/examples/existing-vpc/providers.tf
+++ b/examples/existing-vpc/providers.tf
@@ -1,0 +1,3 @@
+provider "aws" {
+  region = "us-east-1"
+}

--- a/examples/existing-vpc/variables.tf
+++ b/examples/existing-vpc/variables.tf
@@ -1,0 +1,47 @@
+variable "project_name" {
+  type        = string
+  description = "Name prefix for all resources."
+}
+
+variable "vpc_name" {
+  type        = string
+  description = "Name tag of the existing VPC."
+}
+
+variable "route53_zone_name" {
+  type        = string
+  description = "Name of the existing Route 53 hosted zone."
+}
+
+variable "vault_license" {
+  type        = string
+  description = "Vault Enterprise license string."
+  sensitive   = true
+}
+
+variable "ec2_key_pair_name" {
+  type        = string
+  description = "Name of an existing EC2 key pair for SSH access."
+}
+
+variable "ec2_ami_owner" {
+  type        = string
+  description = "AWS account ID of the AMI owner."
+}
+
+variable "ec2_ami_name" {
+  type        = string
+  description = "Name filter for the AMI (supports wildcards)."
+}
+
+variable "nlb_internal" {
+  type        = bool
+  description = "Whether the NLB is internal."
+  default     = true
+}
+
+variable "vault_api_allowed_cidrs" {
+  type        = list(string)
+  description = "CIDR blocks allowed to reach the Vault API (port 8200) from outside the VPC. Only effective when nlb_internal is false."
+  default     = []
+}

--- a/examples/existing-vpc/versions.tf
+++ b/examples/existing-vpc/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "~> 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.37.0"
+    }
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,11 @@ data "aws_availability_zones" "available" {
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
+data "aws_vpc" "existing" {
+  count = var.existing_vpc != null ? 1 : 0
+  id    = var.existing_vpc.vpc_id
+}
+
 locals {
   vault_fqdn        = "${var.vault_subdomain}.${var.route53_zone.name}"
   vault_node_count  = 3
@@ -12,4 +17,16 @@ locals {
   cluster_tag_key   = "vault-cluster"
   cluster_tag_value = var.project_name
   ebs_device_name   = "/dev/xvdf" # AWS convention for the first additional EBS volume
+
+  vpc = var.existing_vpc != null ? {
+    id                 = var.existing_vpc.vpc_id
+    cidr               = data.aws_vpc.existing[0].cidr_block
+    private_subnet_ids = var.existing_vpc.private_subnet_ids
+    public_subnet_ids  = var.existing_vpc.public_subnet_ids
+    } : {
+    id                 = module.vpc[0].vpc_id
+    cidr               = var.vpc_cidr
+    private_subnet_ids = module.vpc[0].private_subnets
+    public_subnet_ids  = module.vpc[0].public_subnets
+  }
 }

--- a/nlb.tf
+++ b/nlb.tf
@@ -2,7 +2,7 @@ resource "aws_lb" "vault" {
   name_prefix        = "vault-"
   internal           = var.nlb_internal
   load_balancer_type = "network"
-  subnets            = var.nlb_internal ? module.vpc.private_subnets : module.vpc.public_subnets
+  subnets            = var.nlb_internal ? local.vpc.private_subnet_ids : local.vpc.public_subnet_ids
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault" })
 
@@ -15,7 +15,7 @@ resource "aws_lb_target_group" "vault" {
   name_prefix = "vault-"
   port        = 8200
   protocol    = "TCP"
-  vpc_id      = module.vpc.vpc_id
+  vpc_id      = local.vpc.id
 
   health_check {
     enabled             = true

--- a/variables.tf
+++ b/variables.tf
@@ -57,6 +57,25 @@ variable "vpc_public_subnets" {
   default     = ["10.0.101.0/24", "10.0.102.0/24", "10.0.103.0/24"]
 }
 
+variable "existing_vpc" {
+  type = object({
+    vpc_id             = string
+    private_subnet_ids = list(string)
+    public_subnet_ids  = list(string)
+  })
+  default     = null
+  description = <<-EOT
+    Existing VPC to deploy into. When null (default), a new VPC is created.
+    The existing VPC must already have the required VPC endpoints:
+    Secrets Manager, KMS, and EC2 (Interface), S3 (Gateway).
+  EOT
+
+  validation {
+    condition     = var.existing_vpc == null || (length(var.existing_vpc.private_subnet_ids) > 0 && length(var.existing_vpc.public_subnet_ids) > 0)
+    error_message = "existing_vpc subnet ID lists must be non-empty."
+  }
+}
+
 # EC2
 
 variable "ec2_ami" {

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,4 +1,6 @@
 module "vpc" {
+  count = var.existing_vpc == null ? 1 : 0
+
   source  = "terraform-aws-modules/vpc/aws"
   version = "6.6.0"
 
@@ -21,43 +23,51 @@ module "vpc" {
 # VPC Endpoints
 
 resource "aws_vpc_endpoint" "secretsmanager" {
-  vpc_id              = module.vpc.vpc_id
+  count = var.existing_vpc == null ? 1 : 0
+
+  vpc_id              = module.vpc[0].vpc_id
   service_name        = "com.amazonaws.${data.aws_region.current.region}.secretsmanager"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = module.vpc.private_subnets
-  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  subnet_ids          = module.vpc[0].private_subnets
+  security_group_ids  = [aws_security_group.vpc_endpoints[0].id]
   private_dns_enabled = true
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault-secretsmanager" })
 }
 
 resource "aws_vpc_endpoint" "kms" {
-  vpc_id              = module.vpc.vpc_id
+  count = var.existing_vpc == null ? 1 : 0
+
+  vpc_id              = module.vpc[0].vpc_id
   service_name        = "com.amazonaws.${data.aws_region.current.region}.kms"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = module.vpc.private_subnets
-  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  subnet_ids          = module.vpc[0].private_subnets
+  security_group_ids  = [aws_security_group.vpc_endpoints[0].id]
   private_dns_enabled = true
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault-kms" })
 }
 
 resource "aws_vpc_endpoint" "ec2" {
-  vpc_id              = module.vpc.vpc_id
+  count = var.existing_vpc == null ? 1 : 0
+
+  vpc_id              = module.vpc[0].vpc_id
   service_name        = "com.amazonaws.${data.aws_region.current.region}.ec2"
   vpc_endpoint_type   = "Interface"
-  subnet_ids          = module.vpc.private_subnets
-  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  subnet_ids          = module.vpc[0].private_subnets
+  security_group_ids  = [aws_security_group.vpc_endpoints[0].id]
   private_dns_enabled = true
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault-ec2" })
 }
 
 resource "aws_vpc_endpoint" "s3" {
-  vpc_id            = module.vpc.vpc_id
+  count = var.existing_vpc == null ? 1 : 0
+
+  vpc_id            = module.vpc[0].vpc_id
   service_name      = "com.amazonaws.${data.aws_region.current.region}.s3"
   vpc_endpoint_type = "Gateway"
-  route_table_ids   = module.vpc.private_route_table_ids
+  route_table_ids   = module.vpc[0].private_route_table_ids
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault-s3" })
 }
@@ -67,7 +77,7 @@ resource "aws_vpc_endpoint" "s3" {
 resource "aws_security_group" "bastion" {
   name_prefix = "${var.project_name}-vault-bastion-"
   description = "Security group for the bastion host"
-  vpc_id      = module.vpc.vpc_id
+  vpc_id      = local.vpc.id
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault-bastion" })
 
@@ -97,7 +107,7 @@ resource "aws_vpc_security_group_egress_rule" "bastion_all" {
 resource "aws_security_group" "vault" {
   name_prefix = "${var.project_name}-vault-"
   description = "Security group for Vault nodes"
-  vpc_id      = module.vpc.vpc_id
+  vpc_id      = local.vpc.id
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault" })
 
@@ -112,7 +122,7 @@ resource "aws_vpc_security_group_ingress_rule" "vault_api" {
   from_port         = 8200
   to_port           = 8200
   ip_protocol       = "tcp"
-  cidr_ipv4         = var.vpc_cidr
+  cidr_ipv4         = local.vpc.cidr
 }
 
 resource "aws_vpc_security_group_ingress_rule" "vault_api_external" {
@@ -152,9 +162,11 @@ resource "aws_vpc_security_group_egress_rule" "vault_all" {
 }
 
 resource "aws_security_group" "vpc_endpoints" {
+  count = var.existing_vpc == null ? 1 : 0
+
   name_prefix = "${var.project_name}-vault-vpc-endpoints-"
   description = "Security group for VPC endpoints"
-  vpc_id      = module.vpc.vpc_id
+  vpc_id      = module.vpc[0].vpc_id
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault-vpc-endpoints" })
 
@@ -164,10 +176,12 @@ resource "aws_security_group" "vpc_endpoints" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "vpc_endpoints_https" {
-  security_group_id = aws_security_group.vpc_endpoints.id
+  count = var.existing_vpc == null ? 1 : 0
+
+  security_group_id = aws_security_group.vpc_endpoints[0].id
   description       = "HTTPS from VPC"
   from_port         = 443
   to_port           = 443
   ip_protocol       = "tcp"
-  cidr_ipv4         = var.vpc_cidr
+  cidr_ipv4         = local.vpc.cidr
 }


### PR DESCRIPTION
- Add `existing_vpc` variable (defaults to `null`) that accepts a pre-existing VPC ID and subnet IDs, allowing the module to deploy into a shared VPC instead of always creating its own
- When `existing_vpc` is set, the VPC module and all VPC endpoints (Secrets Manager, KMS, EC2, S3) are skipped — the existing VPC must already provide them
- All other resources (security groups, EC2 instances, NLB, etc.) use a normalized `local.vpc` object that abstracts over both modes
- Follows the exact same pattern already established in the Consul module (`terraform-aws-consul-enterprise`)
- Fully backward-compatible: when `existing_vpc` is null (default), behavior is identical to before
- Add `examples/existing-vpc/` demonstrating VPC discovery by Name tag and `existing_vpc` passthrough