### PR TITLE
fix: Set EBS delete-on-termination via instance attribute

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -91,7 +91,17 @@ resource "aws_ebs_volume" "vault" {
 resource "aws_volume_attachment" "vault" {
   count = local.vault_node_count
 
-  device_name = local.ebs_device_name
-  volume_id   = aws_ebs_volume.vault[count.index].id
-  instance_id = aws_instance.vault[count.index].id
+  device_name                    = local.ebs_device_name
+  volume_id                      = aws_ebs_volume.vault[count.index].id
+  instance_id                    = aws_instance.vault[count.index].id
+  stop_instance_before_detaching = true
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      aws ec2 modify-instance-attribute \
+        --instance-id ${self.instance_id} \
+        --block-device-mappings '[{"DeviceName":"${self.device_name}","Ebs":{"DeleteOnTermination":true}}]' \
+        --region ${data.aws_region.current.region}
+    EOT
+  }
 }


### PR DESCRIPTION
- Add local-exec provisioner to set EC2 DeleteOnTermination on EBS data volumes
- Ensures volumes are cleaned up if instances are terminated outside Terraform
- Add stop_instance_before_detaching for cleaner Terraform destroy