### PR TITLE
fix: Refactor cloud-init.sh script

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,27 @@
+locals {
+  vault_fqdn        = "${var.vault_subdomain}.${var.route53_zone.name}"
+  vault_node_count  = 3
+  azs               = slice(data.aws_availability_zones.available.names, 0, 3)
+  cluster_tag_key   = "vault-cluster"
+  cluster_tag_value = var.project_name
+  ebs_device_name   = "/dev/xvdf" # AWS convention for the first additional EBS volume
+
+  config_snapshot_json = templatefile("${path.module}/templates/snapshot.json.tftpl", {
+    aws_s3_bucket = aws_s3_bucket.vault_snapshots.id
+    aws_s3_region = data.aws_region.current.region
+    interval      = var.vault_snapshot_interval
+    retain        = var.vault_snapshot_retain
+  })
+
+  vpc = var.existing_vpc != null ? {
+    id                 = var.existing_vpc.vpc_id
+    cidr               = data.aws_vpc.existing[0].cidr_block
+    private_subnet_ids = var.existing_vpc.private_subnet_ids
+    public_subnet_ids  = var.existing_vpc.public_subnet_ids
+    } : {
+    id                 = module.vpc[0].vpc_id
+    cidr               = var.vpc_cidr
+    private_subnet_ids = module.vpc[0].private_subnets
+    public_subnet_ids  = module.vpc[0].public_subnets
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -9,31 +9,3 @@ data "aws_vpc" "existing" {
   count = var.existing_vpc != null ? 1 : 0
   id    = var.existing_vpc.vpc_id
 }
-
-locals {
-  vault_fqdn        = "${var.vault_subdomain}.${var.route53_zone.name}"
-  vault_node_count  = 3
-  azs               = slice(data.aws_availability_zones.available.names, 0, 3)
-  cluster_tag_key   = "vault-cluster"
-  cluster_tag_value = var.project_name
-  ebs_device_name   = "/dev/xvdf" # AWS convention for the first additional EBS volume
-
-  config_snapshot_json = templatefile("${path.module}/templates/snapshot.json.tftpl", {
-    aws_s3_bucket = aws_s3_bucket.vault_snapshots.id
-    aws_s3_region = data.aws_region.current.region
-    interval      = var.vault_snapshot_interval
-    retain        = var.vault_snapshot_retain
-  })
-
-  vpc = var.existing_vpc != null ? {
-    id                 = var.existing_vpc.vpc_id
-    cidr               = data.aws_vpc.existing[0].cidr_block
-    private_subnet_ids = var.existing_vpc.private_subnet_ids
-    public_subnet_ids  = var.existing_vpc.public_subnet_ids
-    } : {
-    id                 = module.vpc[0].vpc_id
-    cidr               = var.vpc_cidr
-    private_subnet_ids = module.vpc[0].private_subnets
-    public_subnet_ids  = module.vpc[0].public_subnets
-  }
-}

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -1,84 +1,250 @@
 #!/bin/sh
-# Disable false positives caused by shellcheck not understanding Terraform's template syntax.
-# shellcheck disable=SC2034,SC2086,SC2154,SC2157,SC2170,SC2193
+# setup-vault-server.sh — Bootstrap a Vault Enterprise server node on EC2.
+#
+# This script is rendered by Terraform using templatefile() and placed in
+# EC2 instance user data.
+#
+# Assumes:
+#   - Ubuntu or Debian
+#   - IAM instance profile with permissions for Secrets Manager and KMS
+#   - Secrets stored in AWS Secrets Manager
+#   - An EBS data volume attached for Raft storage
 
-log() {
-  printf '%b%s %b%s%b %s\n' \
-    "$${c1}" "$${3:-->}" "$${c3}$${2:+$c2}" "$1" "$${c3}" "$2" >&2
+# shellcheck disable=SC2034,SC2154,SC2170,SC2269
+# SC2034/SC2154:
+# Variables are set via Terraform templatefile() interpolation and referenced
+# with escaped dollar signs — shellcheck cannot parse either.
+# SC2170:
+# $${var} comparisons resolve to valid integers at runtime.
+# SC2269:
+# vault_version="${vault_version}" is not self-assignment — the RHS is a
+# Terraform interpolation replaced at plan time.
+
+set -ef
+
+# ---------------------------------------------------------------------------
+# Configuration — values templated by Terraform at deploy time
+# ---------------------------------------------------------------------------
+
+# Vault
+vault_version="${vault_version}"
+vault_data_dir="/opt/vault/data"
+vault_config_dir="/etc/vault.d"
+vault_license_path="/opt/vault/vault.hclic"
+
+# An EBS data volume backs Raft state.
+# ebs_data_device_name is the attachment name from Terraform (e.g. /dev/sdf).
+# On Nitro instances this appears as /dev/nvme*n1 and ebsnvme-id resolves it.
+ebs_data_device_name="${ebs_device_name}"
+ebs_data_mount="/opt/vault/data"
+ebs_data_filesystem="xfs"
+
+# TLS
+tls_ca_file="/opt/vault/tls/ca.crt"
+tls_cert_file="/opt/vault/tls/server.crt"
+tls_key_file="/opt/vault/tls/server.key"
+
+# Snapshot Agent
+snapshot_config_file="/etc/vault.d/snapshot.json"
+
+# AWS
+aws_region="${region}"
+
+# AWS Secrets Manager (ARNs)
+secret_vault_license="${vault_license_secret_arn}"
+secret_vault_ca_cert="${vault_ca_cert_secret_arn}"
+secret_vault_server_cert="${vault_server_cert_secret_arn}"
+secret_vault_server_key="${vault_server_key_secret_arn}"
+
+# EC2 metadata service (IMDSv2)
+imds_endpoint="http://169.254.169.254"
+imds_token_ttl="21600"
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+
+log_info() {
+  printf '[INFO]  %s\n' "$${1}"
 }
 
+log_warn() {
+  printf '[WARN]  %s\n' "$${1}" >&2
+}
+
+log_error() {
+  printf '[ERROR] %s\n' "$${1}" >&2
+}
+
+# ---------------------------------------------------------------------------
+# EC2 metadata helpers (IMDSv2)
+# ---------------------------------------------------------------------------
+
+imds_token() {
+  curl -s -X PUT \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: $${imds_token_ttl}" \
+    "$${imds_endpoint}/latest/api/token"
+}
+
+imds_get() {
+  path="$${1}"
+  token="$${2}"
+  curl -s -H "X-aws-ec2-metadata-token: $${token}" \
+    "$${imds_endpoint}/latest/meta-data/$${path}"
+}
+
+get_private_ip() {
+  token="$(imds_token)"
+  imds_get "local-ipv4" "$${token}"
+}
+
+get_instance_id() {
+  token="$(imds_token)"
+  imds_get "instance-id" "$${token}"
+}
+
+# ---------------------------------------------------------------------------
+# AWS Secrets Manager helper
+# ---------------------------------------------------------------------------
+
+# Vault's variant retries — early-boot Secrets Manager calls have been
+# observed to fail intermittently before the instance profile is fully
+# usable. Consul/Nomad's fetch_secret has no retry; this divergence is
+# intentional.
+fetch_secret() {
+  secret_arn="$${1}"
+
+  attempts=0
+  max_attempts=5
+
+  while true; do
+    if result=$(aws secretsmanager get-secret-value \
+      --region "$${aws_region}" \
+      --secret-id "$${secret_arn}" \
+      --query SecretString --output text 2>/dev/null); then
+      printf '%s' "$${result}"
+      return 0
+    fi
+    attempts=$((attempts + 1))
+    if [ "$${attempts}" -ge "$${max_attempts}" ]; then
+      log_error "Failed to retrieve secret after $${max_attempts} attempts: $${secret_arn}"
+      return 1
+    fi
+    sleep 5
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Network readiness
+# ---------------------------------------------------------------------------
+
 wait_for_network() {
-  log "Checking network connectivity."
+  log_info "Checking network connectivity"
+
   attempts=0
   max_attempts=60
   while ! ping -c 1 -W 1 8.8.8.8 >/dev/null 2>&1; do
-    log "  Waiting for the network to be available..."
+    log_info "Waiting for the network to be available..."
     attempts=$((attempts + 1))
     if [ "$${attempts}" -ge "$${max_attempts}" ]; then
-      log "ERROR: Network not available after $${max_attempts} attempts."
+      log_error "Network not available after $${max_attempts} attempts"
       exit 1
     fi
     sleep 2
   done
 }
 
-install_packages() {
-  log "  Installing the following packages: $*"
+# ---------------------------------------------------------------------------
+# System preparation
+# ---------------------------------------------------------------------------
+
+prepare_system() {
+  log_info "Preparing system packages"
+
   export DEBIAN_FRONTEND=noninteractive
+
   apt-get -yq update >/dev/null
-  apt-get -yq install "$@" >/dev/null
+  apt-get -yq install \
+    awscli jq unzip gnupg lsb-release nvme-cli amazon-ec2-utils >/dev/null
+
+  # The vault-enterprise package creates the vault user, so no useradd here.
 }
 
-find_ebs_device() {
-  log "  Resolving the NVMe device for the ${ebs_device_name} EBS attachment."
+# ---------------------------------------------------------------------------
+# EBS data volume — discover, format, and mount
+# ---------------------------------------------------------------------------
 
-  device=""
-  attempts=0
-  max_attempts=30
+resolve_ebs_nvme_device() {
+  target_name="$${1}"
 
-  # Re-enable globbing within this block; -f is inherited from main().
+  # Strip leading /dev/ from target for comparison — ebsnvme-id returns
+  # the short form (e.g. "sdf") on some versions and the full path on others.
+  target_short="$${target_name#/dev/}"
+
+  # Globbing is disabled by set -f; re-enable for the device scan.
   set +f
-  while [ -z "$${device}" ]; do
-    for dev in /dev/nvme*n1; do
-      [ -b "$${dev}" ] || continue
-      block_dev=$(ebsnvme-id -b "$${dev}" 2>/dev/null)
-      if [ "$${block_dev}" = "${ebs_device_name}" ]; then
-        device="$${dev}"
-        break
-      fi
-    done
+  for nvme in /dev/nvme*n1; do
+    [ -e "$${nvme}" ] || continue
 
-    if [ -z "$${device}" ]; then
-      attempts=$((attempts + 1))
-      if [ "$${attempts}" -ge "$${max_attempts}" ]; then
-        log "ERROR: EBS volume not found after $${max_attempts} attempts."
-        exit 1
-      fi
-      sleep 2
+    # ebsnvme-id -b prints the block device name the volume was attached as.
+    attached="$(ebsnvme-id -b "$${nvme}" 2>/dev/null)" || continue
+    attached_short="$${attached#/dev/}"
+
+    if [ "$${attached_short}" = "$${target_short}" ]; then
+      set -f
+      printf '%s' "$${nvme}"
+      return 0
     fi
   done
   set -f
 
-  printf '%s\n' "$${device}"
+  return 1
 }
 
-format_and_mount_ebs() {
-  log "  Formatting and mounting the EBS volume for Raft storage."
+mount_data_volume() {
+  log_info "Resolving EBS volume attached as $${ebs_data_device_name}"
 
-  if ! blkid "$1" >/dev/null 2>&1; then
-    mkfs.ext4 "$1" >/dev/null
+  if ! command -v ebsnvme-id >/dev/null 2>&1; then
+    log_error "ebsnvme-id not found — ensure amazon-ec2-utils is installed in the AMI"
+    return 1
   fi
 
-  mkdir -p /opt/vault/data
-  mount "$1" /opt/vault/data
+  device="$(resolve_ebs_nvme_device "$${ebs_data_device_name}")" || {
+    log_error "No NVMe device found matching EBS attachment $${ebs_data_device_name}"
+    return 1
+  }
 
-  if ! grep -q '/opt/vault/data' /etc/fstab; then
-    echo "$1 /opt/vault/data ext4 defaults,nofail 0 2" >>/etc/fstab
+  log_info "Matched $${ebs_data_device_name} -> $${device}"
+
+  # Format only if the device has no existing filesystem
+  if ! blkid -p "$${device}" >/dev/null 2>&1; then
+    log_info "Formatting $${device} as $${ebs_data_filesystem}"
+    "mkfs.$${ebs_data_filesystem}" "$${device}"
+  else
+    log_info "Filesystem already present on $${device}, skipping format"
+  fi
+
+  # Mount
+  mkdir -p "$${ebs_data_mount}"
+  mount -t "$${ebs_data_filesystem}" "$${device}" "$${ebs_data_mount}"
+  log_info "Mounted $${device} at $${ebs_data_mount}"
+
+  # Persist in fstab (use UUID for stability across reboots)
+  uuid="$(blkid -s UUID -o value "$${device}")"
+  if ! grep -q "$${uuid}" /etc/fstab; then
+    printf 'UUID=%s  %s  %s  defaults,nofail  0  2\n' \
+      "$${uuid}" "$${ebs_data_mount}" "$${ebs_data_filesystem}" \
+      >>/etc/fstab
+    log_info "Added fstab entry for UUID=$${uuid}"
   fi
 }
+
+# ---------------------------------------------------------------------------
+# Install Vault Enterprise
+# ---------------------------------------------------------------------------
 
 install_vault() {
-  log "  Installing Vault Enterprise ${vault_version}."
+  log_info "Installing Vault Enterprise $${vault_version}"
 
   curl -fsSL https://apt.releases.hashicorp.com/gpg |
     gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
@@ -87,119 +253,112 @@ install_vault() {
     >/etc/apt/sources.list.d/hashicorp.list
 
   apt-get -yq update >/dev/null
-  apt-get -yq install vault-enterprise=${vault_version} >/dev/null
+  apt-get -yq install vault-enterprise=$${vault_version} >/dev/null
 }
 
-get_secret() {
-  log "  Grabbing AWS Secrets Manager secret value for:" "$1"
+# ---------------------------------------------------------------------------
+# Fetch secrets and write sensitive material to disk
+# ---------------------------------------------------------------------------
 
-  attempts=0
-  max_attempts=5
+write_secrets() {
+  log_info "Fetching secrets from AWS Secrets Manager"
 
-  while true; do
-    if result=$(aws secretsmanager get-secret-value \
-      --region "${region}" \
-      --secret-id "$1" \
-      --query SecretString --output text 2>/dev/null); then
-      printf '%s' "$${result}"
-      return 0
-    fi
-    attempts=$((attempts + 1))
-    if [ "$${attempts}" -ge "$${max_attempts}" ]; then
-      log "ERROR: Failed to retrieve secret after $${max_attempts} attempts." "$1"
-      return 1
-    fi
-    sleep 5
-  done
+  vault_license="$(fetch_secret "$${secret_vault_license}")"
+  ca_cert="$(fetch_secret "$${secret_vault_ca_cert}")"
+  server_cert="$(fetch_secret "$${secret_vault_server_cert}")"
+  server_key="$(fetch_secret "$${secret_vault_server_key}")"
+
+  # Write the license file
+  log_info "Writing the Vault license"
+  printf '%s\n' "$${vault_license}" >"$${vault_license_path}"
+  chown vault:vault "$${vault_license_path}"
+  chmod 0640 "$${vault_license_path}"
+
+  # Write TLS certificates
+  log_info "Writing TLS certificates"
+  mkdir -p "$(dirname "$${tls_ca_file}")"
+  printf '%s\n' "$${ca_cert}" >"$${tls_ca_file}"
+  printf '%s\n' "$${server_cert}" >"$${tls_cert_file}"
+  printf '%s\n' "$${server_key}" >"$${tls_key_file}"
+
+  chown vault:vault "$${tls_ca_file}" "$${tls_cert_file}" "$${tls_key_file}"
+  chmod 0640 "$${tls_ca_file}" "$${tls_cert_file}" "$${tls_key_file}"
 }
 
-get_ec2_private_ip_address() {
-  log "  Grabbing the EC2 instance metadata token."
+# ---------------------------------------------------------------------------
+# Generate Vault server configuration
+# ---------------------------------------------------------------------------
 
-  token=$(curl -s -X PUT "http://169.254.169.254/latest/api/token" \
-    -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")
+write_vault_config() {
+  private_ip="$${1}"
 
-  log "  Grabbing the EC2 instance private IPv4 address."
+  log_info "Writing Vault configuration (bind=$${private_ip})"
 
-  curl -s -H "X-aws-ec2-metadata-token: $${token}" \
-    http://169.254.169.254/latest/meta-data/local-ipv4
-}
-
-main() {
-  # Globally disable globbing and enable exit-on-error.
-  set -ef
-
-  # Colors are automatically disabled if output is not a terminal.
-  ! [ -t 2 ] || {
-    c1='\033[1;33m'
-    c2='\033[1;34m'
-    c3='\033[m'
-  }
-
-  # Wait for the network to be available.
-  wait_for_network
-
-  # Install dependencies.
-  log "Setting up system packages."
-  install_packages awscli jq unzip gnupg lsb-release nvme-cli amazon-ec2-utils
-
-  # Format and mount the EBS volume for Raft storage.
-  log "Setting up EBS storage."
-  device="$(find_ebs_device)"
-  format_and_mount_ebs "$${device}"
-
-  # Install Vault Enterprise.
-  log "Setting up Vault Enterprise."
-  install_vault
-
-  # Retrieve secrets from AWS Secrets Manager.
-  log "Retrieving secrets from AWS Secrets Manager."
-  vault_license=$(get_secret "${vault_license_secret_arn}")
-  ca_cert=$(get_secret "${vault_ca_cert_secret_arn}")
-  server_cert=$(get_secret "${vault_server_cert_secret_arn}")
-  server_key=$(get_secret "${vault_server_key_secret_arn}")
-
-  # Write TLS certificates.
-  log "Writing TLS certificates."
-  mkdir -p /opt/vault/tls
-  printf '%s\n' "$${ca_cert}" >/opt/vault/tls/ca.crt
-  printf '%s\n' "$${server_cert}" >/opt/vault/tls/server.crt
-  printf '%s\n' "$${server_key}" >/opt/vault/tls/server.key
-  chmod 640 /opt/vault/tls/ca.crt /opt/vault/tls/server.crt /opt/vault/tls/server.key
-  chown vault:vault /opt/vault/tls/ca.crt /opt/vault/tls/server.crt /opt/vault/tls/server.key
-
-  # Write Vault license.
-  log "Writing the Vault license."
-  printf '%s\n' "$${vault_license}" >/opt/vault/vault.hclic
-  chmod 640 /opt/vault/vault.hclic
-  chown vault:vault /opt/vault/vault.hclic
-
-  # Write Vault configuration.
-  private_ip="$(get_ec2_private_ip_address)"
-
-  log "Generating the /etc/vault.d/vault.hcl configuration file."
-  cat >/etc/vault.d/vault.hcl <<'EOF'
+  # vault.hcl — contains $${private_ip} shell variable, needs unquoted heredoc.
+  cat >"$${vault_config_dir}/vault.hcl" <<EOF
 ${config_vault_hcl}
 EOF
-  sed -i "s/__PRIVATE_IP__/$${private_ip}/g" /etc/vault.d/vault.hcl
 
-  chown vault:vault /etc/vault.d/vault.hcl
-  chmod 640 /etc/vault.d/vault.hcl
+  chown vault:vault "$${vault_config_dir}/vault.hcl"
+  chmod 0640 "$${vault_config_dir}/vault.hcl"
 
   # Set permissions on data directory.
-  chown -R vault:vault /opt/vault/data
-
-  # Write the snapshot configuration for the operator to apply post-init.
-  log "Writing the snapshot configuration."
-  cat >/etc/vault.d/snapshot.json <<'EOF'
-${config_snapshot_json}
-EOF
-  chown vault:vault /etc/vault.d/snapshot.json
-  chmod 640 /etc/vault.d/snapshot.json
-
-  # Enable and start the Vault service.
-  log "Enabling the Vault service."
-  systemctl enable --now vault
+  chown -R vault:vault "$${vault_data_dir}"
 }
 
-main "$@"
+# ---------------------------------------------------------------------------
+# Generate snapshot configuration
+# ---------------------------------------------------------------------------
+
+write_snapshot_config() {
+  log_info "Writing snapshot configuration"
+
+  cat >"$${snapshot_config_file}" <<'EOF'
+${config_snapshot_json}
+EOF
+  chown vault:vault "$${snapshot_config_file}"
+  chmod 0640 "$${snapshot_config_file}"
+}
+
+# ---------------------------------------------------------------------------
+# Enable and start services
+# ---------------------------------------------------------------------------
+
+start_services() {
+  log_info "Enabling the Vault service"
+
+  # Vault starts sealed; no health-check loop here because /v1/sys/health
+  # returns non-2xx until init/unseal is performed by an operator.
+  systemctl enable --now vault
+
+  log_info "All services started"
+}
+
+# ---------------------------------------------------------------------------
+# Entrypoint
+# ---------------------------------------------------------------------------
+
+main() {
+  log_info "=== Vault Enterprise server bootstrap ==="
+
+  wait_for_network
+
+  private_ip="$(get_private_ip)"
+  instance_id="$(get_instance_id)"
+
+  log_info "Instance $${instance_id} at $${private_ip}"
+
+  prepare_system
+  mount_data_volume
+  install_vault
+
+  write_secrets
+  write_vault_config "$${private_ip}"
+  write_snapshot_config
+
+  start_services
+
+  log_info "=== Bootstrap complete ==="
+}
+
+main "$${@}"

--- a/templates/vault.hcl.tftpl
+++ b/templates/vault.hcl.tftpl
@@ -1,7 +1,7 @@
 ui            = true
 disable_mlock = false
 
-cluster_addr = "https://__PRIVATE_IP__:8201"
+cluster_addr = "https://$${private_ip}:8201"
 api_addr     = "https://${vault_fqdn}:8200"
 license_path = "/opt/vault/vault.hclic"
 


### PR DESCRIPTION
- Align templates/cloud-init.sh.tftpl with the Consul/Nomad user-data.sh.tftpl idiom: header docstring, numbered shellcheck-disable block, top-of-file configuration section, # --- section banners, three-level log_info/log_warn/log_error, IMDSv2 helpers, fetch_secret, prepare_system/mount_data_volume/resolve_ebs_nvme_device/write_secrets/write_vault_config/write_snapshot_config/start_services, and a restructured main()
- Switch the Raft EBS data volume from ext4 to xfs (matches Consul/Nomad) — destroy/recreate required for existing clusters; in-place ext4 volumes will not auto-convert
- Switch the /etc/fstab entry from device-path-based to UUID-based for stability across NVMe device renumbering
- Render vault.hcl via an unquoted heredoc that expands ${private_ip} directly; drop the __PRIVATE_IP__ sed substitution. templates/vault.hcl.tftpl updated in lockstep (cluster_addr now uses $${private_ip})
- Preserve wait_for_network (ping 8.8.8.8), the fetch_secret retry loop, the apt-based Vault install, the package list, all TLS/license/snapshot paths and modes, and the no-health-wait service start (Vault boots sealed)
- Move the locals block out of main.tf into a new locals.tf to match the Consul and Nomad module layout; no functional change