### PR TITLE
chore: Add cluster_name, log config, and telemetry block

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -45,6 +45,7 @@ resource "aws_instance" "vault" {
     vault_server_key_secret_arn  = aws_secretsmanager_secret.vault_server_key.arn
 
     config_vault_hcl = templatefile("${path.module}/templates/vault.hcl.tftpl", {
+      cluster_name      = var.project_name
       vault_fqdn        = trimsuffix(aws_route53_record.vault.fqdn, ".")
       node_id           = "vault-${count.index}"
       region            = data.aws_region.current.region

--- a/templates/vault.hcl.tftpl
+++ b/templates/vault.hcl.tftpl
@@ -1,5 +1,9 @@
 ui            = true
 disable_mlock = true
+cluster_name  = "${cluster_name}"
+
+log_level  = "info"
+log_format = "json"
 
 cluster_addr = "https://$${private_ip}:8201"
 api_addr     = "https://${vault_fqdn}:8200"
@@ -28,4 +32,9 @@ storage "raft" {
 seal "awskms" {
   region     = "${region}"
   kms_key_id = "${kms_key_alias}"
+}
+
+telemetry {
+  prometheus_retention_time = "24h"
+  disable_hostname          = true
 }


### PR DESCRIPTION
Make previously-implicit defaults explicit:

- cluster_name: avoids randomly-generated names in telemetry labels,
  which destabilize Grafana dashboards across cluster rebuilds
- log_level/log_format: explicit info+json for downstream log shipping
- telemetry: enable Prometheus endpoint with 24h retention

Pure additions, no behavior change to existing functionality.