### PR TITLE
refactor: Harden TLS listener config

### DIFF
--- a/templates/vault.hcl.tftpl
+++ b/templates/vault.hcl.tftpl
@@ -10,11 +10,12 @@ api_addr     = "https://${vault_fqdn}:8200"
 license_path = "/opt/vault/vault.hclic"
 
 listener "tcp" {
-  address            = "0.0.0.0:8200"
-  cluster_address    = "0.0.0.0:8201"
-  tls_cert_file      = "/opt/vault/tls/server.crt"
-  tls_key_file       = "/opt/vault/tls/server.key"
-  tls_client_ca_file = "/opt/vault/tls/ca.crt"
+  address                  = "0.0.0.0:8200"
+  cluster_address          = "0.0.0.0:8201"
+  tls_cert_file            = "/opt/vault/tls/server.crt"
+  tls_key_file             = "/opt/vault/tls/server.key"
+  tls_min_version          = "tls13"
+  tls_disable_client_certs = true
 }
 
 storage "raft" {


### PR DESCRIPTION
Three security-posture improvements to the Vault listener:

- tls_min_version=tls13: greenfield cluster, no legacy clients,
  no reason to allow TLS 1.2
- tls_disable_client_certs=true: makes intent explicit; we are
  not using cert auth on this listener
- Remove tls_client_ca_file: was previously set without purpose;
  caused the listener to request client certs during handshake
  for no functional reason