### PR TITLE
feat: Enable cross-zone load balancing on Vault NLB

### DIFF
--- a/nlb.tf
+++ b/nlb.tf
@@ -4,6 +4,8 @@ resource "aws_lb" "vault" {
   load_balancer_type = "network"
   subnets            = var.nlb_internal ? local.vpc.private_subnet_ids : local.vpc.public_subnet_ids
 
+  enable_cross_zone_load_balancing = true
+
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault" })
 
   lifecycle {


### PR DESCRIPTION
NLBs default to `cross_zone_load_balancing=false`, which means traffic only routes to targets in the same AZ as the client connection's AZ on the NLB side. For a 3-node Raft cluster across 3 AZs this causes uneven load and unpredictable failover behavior if a whole AZ's worth of targets goes unhealthy.

Inter-AZ data transfer cost is negligible for a lab cluster.