### PR TITLE
feat: Restrict Vault server key access via resource policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ module "vault" {
 | [aws_secretsmanager_secret.vault_license](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.vault_server_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.vault_server_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_policy.vault_server_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_policy) | resource |
 | [aws_secretsmanager_secret_version.vault_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.vault_license](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.vault_server_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
@@ -210,6 +211,7 @@ module "vault" {
 | [aws_iam_policy_document.vault_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vault_server_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_snapshots](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_vpc.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |

--- a/tls.tf
+++ b/tls.tf
@@ -99,6 +99,26 @@ resource "aws_secretsmanager_secret_version" "vault_server_key" {
   secret_string = tls_private_key.server.private_key_pem
 }
 
+resource "aws_secretsmanager_secret_policy" "vault_server_key" {
+  secret_arn = aws_secretsmanager_secret.vault_server_key.arn
+  policy     = data.aws_iam_policy_document.vault_server_key.json
+}
+
+data "aws_iam_policy_document" "vault_server_key" {
+  statement {
+    sid    = "AllowVaultInstanceRole"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.vault.arn]
+    }
+
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = [aws_secretsmanager_secret.vault_server_key.arn]
+  }
+}
+
 resource "aws_secretsmanager_secret" "vault_license" {
   name_prefix = "${var.project_name}-vault-license-"
   description = "Vault Enterprise license"


### PR DESCRIPTION
Adds an explicit Secrets Manager resource policy on the Vault server private key, restricting `GetSecretValue` to the Vault EC2 instance role. Previously, access was governed only by the IAM role's identity policy; this adds defense-in-depth at the resource boundary itself.

The CA cert and license secrets are intentionally left without resource policies (only the server private key is sensitive enough to justify the extra control).