### PR TITLE
refactor: Switch CA and server keys to Ed25519

### DIFF
--- a/templates/vault.hcl.tftpl
+++ b/templates/vault.hcl.tftpl
@@ -14,6 +14,8 @@ listener "tcp" {
   cluster_address          = "0.0.0.0:8201"
   tls_cert_file            = "/opt/vault/tls/server.crt"
   tls_key_file             = "/opt/vault/tls/server.key"
+  tls_min_version          = "tls12"
+  tls_cipher_suites        = "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384"
   tls_disable_client_certs = true
 }
 

--- a/templates/vault.hcl.tftpl
+++ b/templates/vault.hcl.tftpl
@@ -14,7 +14,6 @@ listener "tcp" {
   cluster_address          = "0.0.0.0:8201"
   tls_cert_file            = "/opt/vault/tls/server.crt"
   tls_key_file             = "/opt/vault/tls/server.key"
-  tls_min_version          = "tls13"
   tls_disable_client_certs = true
 }
 

--- a/tls.tf
+++ b/tls.tf
@@ -1,8 +1,7 @@
 # CA
 
 resource "tls_private_key" "ca" {
-  algorithm = "RSA"
-  rsa_bits  = 4096
+  algorithm = "ED25519"
 }
 
 resource "tls_self_signed_cert" "ca" {
@@ -25,8 +24,7 @@ resource "tls_self_signed_cert" "ca" {
 # Server
 
 resource "tls_private_key" "server" {
-  algorithm = "RSA"
-  rsa_bits  = 4096
+  algorithm = "ED25519"
 }
 
 resource "tls_cert_request" "server" {

--- a/tls.tf
+++ b/tls.tf
@@ -1,7 +1,8 @@
 # CA
 
 resource "tls_private_key" "ca" {
-  algorithm = "ED25519"
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P384"
 }
 
 resource "tls_self_signed_cert" "ca" {
@@ -24,7 +25,8 @@ resource "tls_self_signed_cert" "ca" {
 # Server
 
 resource "tls_private_key" "server" {
-  algorithm = "ED25519"
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P384"
 }
 
 resource "tls_cert_request" "server" {
@@ -54,8 +56,7 @@ resource "tls_locally_signed_cert" "server" {
   allowed_uses = [
     "digital_signature",
     "key_encipherment",
-    "server_auth",
-    "client_auth",
+    "server_auth"
   ]
 }
 


### PR DESCRIPTION
Replace RSA 4096 with Ed25519 for both the bootstrap CA and the Vault server cert. Ed25519 is constant-time by design, uses deterministic signatures (no per-signature RNG dependency), has smaller keys and signatures than equivalent-strength NIST curves, and uses curve parameters chosen openly with no nothing-up-my-sleeve
concerns.

Supported by `hashicorp/tls` v3.2.0+ and Go `crypto/x509` since 1.13. The cert request and signing resources handle the key type change transparently.

Note: NLB HTTPS health checks against Ed25519 server certs are unverified. If targets go unhealthy after apply, revert this commit and fall back to ECDSA P-384 on the server key (CA can stay Ed25519 either way).