### PR TITLE
feat: Add configure_time() for NTP sync and UTC timezone

### DIFF
--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -165,9 +165,24 @@ prepare_system() {
 
   apt-get -yq update >/dev/null
   apt-get -yq install \
-    awscli jq unzip gnupg lsb-release nvme-cli amazon-ec2-utils >/dev/null
+    awscli jq unzip gnupg lsb-release nvme-cli amazon-ec2-utils chrony >/dev/null
 
   # The vault-enterprise package creates the vault user, so no useradd here.
+}
+
+# ---------------------------------------------------------------------------
+# Time synchronization — required before any AWS Secrets Manager calls
+# ---------------------------------------------------------------------------
+
+configure_time() {
+  log_info "Configuring system time"
+
+  timedatectl set-timezone UTC
+  log_info "Timezone set to UTC"
+
+  systemctl enable --now chrony
+  chronyc makestep
+  log_info "Time synchronization complete"
 }
 
 # ---------------------------------------------------------------------------
@@ -349,6 +364,7 @@ main() {
   log_info "Instance $${instance_id} at $${private_ip}"
 
   prepare_system
+  configure_time
   mount_data_volume
   install_vault
 


### PR DESCRIPTION
SigV4 request signing requires the instance clock to be within 5 minutes of AWS time. On a fresh instance, cloud-init runs before NTP has had a chance to discipline the clock (particularly pronounced on instances that have been stopped and restarted, where the hardware clock may have drifted significantly).

Changes
- `chrony` added to the `prepare_system()` package install block
- New `configure_time()` function: sets UTC timezone, enables `chrony`, forces an immediate step sync via `chronyc makestep`
- Called in `main()` after `prepare_system()`, before `mount_data_volume()` and all `fetch_secret()` calls

Why `chrony` over `systemd-timesyncd`?

`chrony` is more aggressive about correcting large initial offsets (it will step the clock immediately on first sync rather than slewing slowly). `systemd-timesyncd` slews, which means a freshly booted instance with a drifted clock could take minutes to correct. For a bootstrap script where Secrets Manager calls happen within seconds of boot, step correction is the right behaviour.