### PR TITLE
feat: Add SSM parameter and Secrets Manager secrets for cluster init

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,12 @@ module "vault" {
 | [aws_ebs_volume.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ebs_volume) | resource |
 | [aws_iam_instance_profile.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.vault_cluster_init](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.vault_ec2_describe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.vault_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.vault_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.vault_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.vault_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_instance.bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_instance.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_kms_alias.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
@@ -173,6 +175,8 @@ module "vault" {
 | [aws_s3_bucket_versioning.vault_snapshots](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_secretsmanager_secret.vault_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.vault_license](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.vault_recovery_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.vault_root_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.vault_server_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.vault_server_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_policy.vault_server_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_policy) | resource |
@@ -183,6 +187,7 @@ module "vault" {
 | [aws_security_group.bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vpc_endpoints](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_ssm_parameter.vault_cluster_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_volume_attachment.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |
 | [aws_vpc_endpoint.ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
@@ -204,12 +209,14 @@ module "vault" {
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.vault_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vault_cluster_init](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_ec2_describe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_server_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_snapshots](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vault_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_vpc.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 

--- a/cluster-init.tf
+++ b/cluster-init.tf
@@ -1,0 +1,37 @@
+resource "aws_secretsmanager_secret" "vault_root_token" {
+  name_prefix = "${var.project_name}-vault-root-token-"
+  description = "Vault root token — written at cluster init, revoked after Terraform handoff"
+
+  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-root-token" })
+}
+
+resource "aws_secretsmanager_secret" "vault_recovery_keys" {
+  name_prefix = "${var.project_name}-vault-recovery-keys-"
+  description = "Vault recovery keys — written at cluster init"
+
+  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-recovery-keys" })
+}
+
+data "aws_iam_policy_document" "vault_cluster_init" {
+  statement {
+    sid    = "ClusterInitReadWrite"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutSecretValue",
+    ]
+    resources = [
+      aws_secretsmanager_secret.vault_root_token.arn,
+      aws_secretsmanager_secret.vault_recovery_keys.arn,
+    ]
+  }
+}
+
+# All nodes receive PutSecretValue because they share a single instance profile.
+# In practice only the elected bootstrap node writes to these secrets.
+# Acceptable for a lab deployment.
+resource "aws_iam_role_policy" "vault_cluster_init" {
+  name_prefix = "${var.project_name}-cluster-init-"
+  role        = aws_iam_role.vault.id
+  policy      = data.aws_iam_policy_document.vault_cluster_init.json
+}

--- a/ssm.tf
+++ b/ssm.tf
@@ -1,0 +1,33 @@
+resource "aws_ssm_parameter" "vault_cluster_state" {
+  name        = "/${var.project_name}/vault/cluster/state"
+  type        = "String"
+  value       = "uninitialized"
+  description = "Vault cluster initialization state flag (uninitialized | ready | managed)"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-cluster-state" })
+}
+
+data "aws_iam_policy_document" "vault_ssm" {
+  statement {
+    sid    = "ClusterStateReadWrite"
+    effect = "Allow"
+    actions = [
+      "ssm:GetParameter",
+      "ssm:PutParameter",
+    ]
+    resources = [aws_ssm_parameter.vault_cluster_state.arn]
+  }
+}
+
+# All nodes receive PutParameter because they share a single instance profile.
+# In practice only the elected bootstrap node writes to this parameter.
+# Acceptable for a lab deployment.
+resource "aws_iam_role_policy" "vault_ssm" {
+  name_prefix = "${var.project_name}-ssm-"
+  role        = aws_iam_role.vault.id
+  policy      = data.aws_iam_policy_document.vault_ssm.json
+}


### PR DESCRIPTION
Provisions the AWS-side infrastructure required by the cluster initialization logic that will be added to `cloud-init` in a subsequent PR.

The cluster state flag is non-sensitive (plain strings: uninitialized, ready, managed) so it lives in SSM Parameter Store rather than Secrets Manager (simpler API and no cost for standard-tier parameters). Sensitive material (root token, recovery keys) stays in Secrets Manager.

New resources in `ssm.tf`:
- `aws_ssm_parameter.vault_cluster_state`: coordination flag polled by follower nodes. Seeded with uninitialized" so followers can read it immediately at boot. A lifecycle `ignore_changes` rule prevents terraform apply from resetting the value after `cloud-init` writes "ready" or "managed".
- `aws_iam_role_policy.vault_ssm`: grants `GetParameter` and `PutParameter` on the state parameter to the shared Vault instance role.

New resources in `cluster-init.tf`:
- `aws_secretsmanager_secret.vault_root_token`: receives the root token output of `operator init`. Written by the bootstrap node, overwritten with the literal string `REVOKED` after the Terraform auth handoff is complete.
- `aws_secretsmanager_secret.vault_recovery_keys`: receives the recovery key output of `operator init` as a JSON array. Written once, never overwritten.
- `aws_iam_role_policy.vault_cluster_init`: grants `GetSecretValue` and `PutSecretValue` on both secrets to the shared Vault instance role. All nodes receive `PutSecretValue` because they share a single instance profile (scoping write access to the bootstrap node only is not possible at the IAM layer without separate profiles).

Shell changes that consume these resources will come in a later PR.