### PR TITLE
feat: Add wait_for_vault_api() to poll health endpoint after start

### DIFF
--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -10,12 +10,18 @@
 #   - Secrets stored in AWS Secrets Manager
 #   - An EBS data volume attached for Raft storage
 
-# shellcheck disable=SC2034,SC2154,SC2170,SC2269
+# shellcheck disable=SC2034,SC2086,SC2154,SC2170,SC2193,SC2269
 # SC2034/SC2154:
 # Variables are set via Terraform templatefile() interpolation and referenced
 # with escaped dollar signs — shellcheck cannot parse either.
+# SC2086:
+# vault_version is a Terraform-templated version string with no whitespace
+# or globs — quoting is unnecessary.
 # SC2170:
 # $${var} comparisons resolve to valid integers at runtime.
+# SC2193:
+# curl -w '%%{http_code}' returns runtime HTTP status codes; shellcheck
+# reads the literal format string and cannot see the comparison is valid.
 # SC2269:
 # vault_version="${vault_version}" is not self-assignment — the RHS is a
 # Terraform interpolation replaced at plan time.
@@ -135,21 +141,28 @@ fetch_secret() {
 }
 
 # ---------------------------------------------------------------------------
-# Network readiness
+# Wait for the network to be available before starting
 # ---------------------------------------------------------------------------
 
 wait_for_network() {
-  log_info "Checking network connectivity"
+  log_info "Waiting for network to become available"
 
   attempts=0
   max_attempts=60
-  while ! ping -c 1 -W 1 8.8.8.8 >/dev/null 2>&1; do
-    log_info "Waiting for the network to be available..."
+
+  while true; do
+    if ping -c 1 -W 1 8.8.8.8 >/dev/null 2>&1; then
+      log_info "Network is available"
+      return 0
+    fi
+
     attempts=$((attempts + 1))
     if [ "$${attempts}" -ge "$${max_attempts}" ]; then
-      log_error "Network not available after $${max_attempts} attempts"
-      exit 1
+      log_error "Network did not become available after $${max_attempts} attempts"
+      return 1
     fi
+
+    log_info "Network not yet available, retrying ($${attempts}/$${max_attempts})"
     sleep 2
   done
 }
@@ -362,8 +375,8 @@ wait_for_vault_api() {
   while true; do
     # curl returns 0 for any completed HTTP exchange regardless of status code.
     # We capture the HTTP status and treat anything other than 000 (no connection)
-    # as success — 501 means uninitialized, 503 means sealed, 200/429 means
-    # active/standby. All indicate the API is up and TLS is working.
+    # as success (501 means uninitialized, 503 means sealed, 200/429 means
+    # active/standby). All indicate the API is up and TLS is working.
     # -k is intentional: the bootstrap cert is self-signed and we are connecting
     # to 127.0.0.1, so hostname validation provides no security here.
     status="$(curl -sk -o /dev/null -w '%%{http_code}' \

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -350,6 +350,42 @@ start_services() {
 }
 
 # ---------------------------------------------------------------------------
+# Wait for the Vault API to respond on the local listener
+# ---------------------------------------------------------------------------
+
+wait_for_vault_api() {
+  log_info "Waiting for Vault API to become available"
+
+  attempts=0
+  max_attempts=60
+
+  while true; do
+    # curl returns 0 for any completed HTTP exchange regardless of status code.
+    # We capture the HTTP status and treat anything other than 000 (no connection)
+    # as success — 501 means uninitialized, 503 means sealed, 200/429 means
+    # active/standby. All indicate the API is up and TLS is working.
+    # -k is intentional: the bootstrap cert is self-signed and we are connecting
+    # to 127.0.0.1, so hostname validation provides no security here.
+    status="$(curl -sk -o /dev/null -w '%%{http_code}' \
+      "https://127.0.0.1:8200/v1/sys/health" 2>/dev/null)" || true
+
+    if [ "$${status}" != "000" ]; then
+      log_info "Vault API responding (HTTP $${status})"
+      return 0
+    fi
+
+    attempts=$((attempts + 1))
+    if [ "$${attempts}" -ge "$${max_attempts}" ]; then
+      log_error "Vault API did not respond after $${max_attempts} attempts"
+      return 1
+    fi
+
+    log_info "Vault API not yet available, retrying ($${attempts}/$${max_attempts})"
+    sleep 5
+  done
+}
+
+# ---------------------------------------------------------------------------
 # Entrypoint
 # ---------------------------------------------------------------------------
 
@@ -373,6 +409,7 @@ main() {
   write_snapshot_config
 
   start_services
+  wait_for_vault_api
 
   log_info "=== Bootstrap complete ==="
 }


### PR DESCRIPTION
Prerequisite for the cluster initialization PR.

After `systemctl enable --now vault` returns, the Vault process may not yet be accepting TLS connections (it needs time to load its config, open the Raft database, and bind the listener. The cluster init logic in the next PR must not attempt `vault operator init` or `raft join` until the API is confirmed reachable.

Changes:
- New `wait_for_vault_api()` function polls `/v1/sys/health` over `HTTPS` on `127.0.0.1:8200` with a 5-second retry interval and a 5-minute ceiling (60 attempts).
- Called in `main()` immediately after `start_services()`.

HTTP status handling:
- Any completed HTTP exchange (non-000 `curl` status) is treated as `success`. The relevant status codes at this point in the lifecycle are `501` (uninitialized, the expected state on a fresh node) and `503` (sealed, also possible before KMS auto-unseal completes). Both indicate the API is up and TLS is working. Treating them as success
is correct (distinguishing between them is the job of the cluster init logic, not this function).

The `-k` flag in `curl` is intentional: the bootstrap cert is self-signed and the connection is to `127.0.0.1`, so hostname validation provides no security benefit here.

No Terraform changes.