### PR TITLE
feat: Add SSM parameters and IAM for PKI bootstrap coordination

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,8 @@ module "vault" {
 | [aws_security_group.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vpc_endpoints](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_ssm_parameter.vault_cluster_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.vault_pki_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.vault_pki_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_volume_attachment.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/volume_attachment) | resource |
 | [aws_vpc_endpoint.ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |

--- a/ec2.tf
+++ b/ec2.tf
@@ -47,6 +47,8 @@ resource "aws_instance" "vault" {
     cluster_tag_key                = local.cluster_tag_key
     cluster_tag_value              = local.cluster_tag_value
     ssm_cluster_state_name         = aws_ssm_parameter.vault_cluster_state.name
+    ssm_pki_state_name             = aws_ssm_parameter.vault_pki_state.name
+    ssm_pki_ca_cert_name           = aws_ssm_parameter.vault_pki_ca_cert.name
     vault_root_token_secret_arn    = aws_secretsmanager_secret.vault_root_token.arn
     vault_recovery_keys_secret_arn = aws_secretsmanager_secret.vault_recovery_keys.arn
 

--- a/ssm.tf
+++ b/ssm.tf
@@ -11,6 +11,32 @@ resource "aws_ssm_parameter" "vault_cluster_state" {
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault-cluster-state" })
 }
 
+resource "aws_ssm_parameter" "vault_pki_state" {
+  name        = "/${var.project_name}/vault/pki/state"
+  type        = "String"
+  value       = "uninitialized"
+  description = "Vault PKI bootstrap state flag (uninitialized | ready)"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-pki-state" })
+}
+
+resource "aws_ssm_parameter" "vault_pki_ca_cert" {
+  name        = "/${var.project_name}/vault/pki/ca-cert"
+  type        = "String"
+  value       = "uninitialized"
+  description = "Vault PKI CA certificate PEM — published by bootstrap node after PKI configuration"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-pki-ca-cert" })
+}
+
 data "aws_iam_policy_document" "vault_ssm" {
   statement {
     sid    = "ClusterStateReadWrite"
@@ -19,7 +45,11 @@ data "aws_iam_policy_document" "vault_ssm" {
       "ssm:GetParameter",
       "ssm:PutParameter",
     ]
-    resources = [aws_ssm_parameter.vault_cluster_state.arn]
+    resources = [
+      aws_ssm_parameter.vault_cluster_state.arn,
+      aws_ssm_parameter.vault_pki_state.arn,
+      aws_ssm_parameter.vault_pki_ca_cert.arn,
+    ]
   }
 }
 

--- a/ssm.tf
+++ b/ssm.tf
@@ -28,7 +28,7 @@ resource "aws_ssm_parameter" "vault_pki_ca_cert" {
   name        = "/${var.project_name}/vault/pki/ca-cert"
   type        = "String"
   value       = "uninitialized"
-  description = "Vault PKI CA certificate PEM — published by bootstrap node after PKI configuration"
+  description = "Vault PKI CA certificate PEM (public)"
 
   lifecycle {
     ignore_changes = [value]


### PR DESCRIPTION
Provisions the AWS-side infrastructure required by the PKI bootstrap logic that will be added to cloud-init in subsequent PRs.

New resources in `ssm.tf`:
- `aws_ssm_parameter.vault_pki_state`: coordination flag used by follower nodes to detect when the bootstrap node has finished configuring the PKI secrets engine and AWS auth method. Seeded with "uninitialized". A `lifecycle ignore_changes` rule prevents `terraform apply` from resetting the value after cloud-init writes
  "ready".
- `aws_ssm_parameter.vault_pki_ca_cert`: CA certificate PEM written by the bootstrap node immediately after generating the PKI root CA, before any node performs a TLS cert swap. Follower nodes fetch this to establish trust in the new CA before attempting to authenticate via the AWS auth method. The CA certificate is public material (it is the trust anchor distributed to clients, not the signing key, which is generated inside Vault's PKI engine and never exposed). SSM String type (unencrypted) is appropriate. Seeded with "uninitialized" and protected by `lifecycle
ignore_changes`.

Updated resources in `ssm.tf`:
- `data.aws_iam_policy_document.vault_ssm`: the two new parameter ARNs added to the resources list. The existing `aws_iam_role_policy` resource is unchanged (it already references this document).

Updated resources in `ec2.tf`:
- `ssm_pki_state_name` and `ssm_pki_ca_cert_name` threaded into the `templatefile()` vars map. The cloud-init template does not yet reference these variables (they are added now so the next PR's shell changes have the values available without requiring a second Terraform change).