### PR TITLE
feat: Add PKI engine and AWS auth configuration to bootstrap path

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ module "vault" {
 | [aws_iam_role.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.vault_cluster_init](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.vault_ec2_describe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.vault_iam_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.vault_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.vault_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_role_policy.vault_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
@@ -213,6 +214,7 @@ module "vault" {
 | [aws_iam_policy_document.vault_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_cluster_init](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_ec2_describe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vault_iam_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/ec2.tf
+++ b/ec2.tf
@@ -49,6 +49,8 @@ resource "aws_instance" "vault" {
     ssm_cluster_state_name         = aws_ssm_parameter.vault_cluster_state.name
     ssm_pki_state_name             = aws_ssm_parameter.vault_pki_state.name
     ssm_pki_ca_cert_name           = aws_ssm_parameter.vault_pki_ca_cert.name
+    vault_fqdn                     = local.vault_fqdn
+    vault_iam_role_arn             = aws_iam_role.vault.arn
     vault_root_token_secret_arn    = aws_secretsmanager_secret.vault_root_token.arn
     vault_recovery_keys_secret_arn = aws_secretsmanager_secret.vault_recovery_keys.arn
 

--- a/iam.tf
+++ b/iam.tf
@@ -104,3 +104,22 @@ resource "aws_iam_role_policy" "vault_ec2_describe" {
   role        = aws_iam_role.vault.id
   policy      = data.aws_iam_policy_document.vault_ec2_describe.json
 }
+
+# IAM (AWS auth method role ARN resolution)
+
+data "aws_iam_policy_document" "vault_iam_read" {
+  statement {
+    sid    = "ResolveIAMRoleARN"
+    effect = "Allow"
+    actions = [
+      "iam:GetRole",
+    ]
+    resources = [aws_iam_role.vault.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "vault_iam_read" {
+  name_prefix = "${var.project_name}-iam-read-"
+  role        = aws_iam_role.vault.id
+  policy      = data.aws_iam_policy_document.vault_iam_read.json
+}

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -571,10 +571,12 @@ configure_pki_engine() {
     key_bits=384 |
     jq -r '.data.certificate' >/dev/null
 
-  # Configure CRL and issuing certificate URLs. OCSP is not configured.
+  # Configure issuing certificate, CRL, and OCSP URLs.
+  # Vault's built-in OCSP responder handles /v1/pki/ocsp natively.
   vault write pki/config/urls \
     issuing_certificates="https://$${vault_fqdn}:8200/v1/pki/ca" \
-    crl_distribution_points="https://$${vault_fqdn}:8200/v1/pki/crl"
+    crl_distribution_points="https://$${vault_fqdn}:8200/v1/pki/crl" \
+    ocsp_servers="https://$${vault_fqdn}:8200/v1/pki/ocsp"
 
   # Create the vault-server role used by nodes to issue their own TLS certs.
   vault write pki/roles/vault-server \

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -561,16 +561,17 @@ configure_pki_engine() {
 
   vault secrets tune -max-lease-ttl=87600h pki
 
-  # Generate root CA with Ed25519 keys. Ed25519 CAs do not support OCSP in
-  # Vault PKI — CRL distribution is configured below instead.
+  # Generate root CA with ECDSA P-384 keys, consistent with the bootstrap
+  # CA and server certs in tls.tf. OCSP is not configured — CRL distribution
+  # is used instead.
   vault write -format=json pki/root/generate/internal \
     common_name="${cluster_tag_value} CA" \
     ttl=87600h \
-    key_type=ed25519 |
+    key_type=ec \
+    key_bits=384 |
     jq -r '.data.certificate' >/dev/null
 
-  # Configure CRL and issuing certificate URLs. OCSP is intentionally omitted
-  # — Ed25519 root CAs do not support it in Vault PKI.
+  # Configure CRL and issuing certificate URLs. OCSP is not configured.
   vault write pki/config/urls \
     issuing_certificates="https://$${vault_fqdn}:8200/v1/pki/ca" \
     crl_distribution_points="https://$${vault_fqdn}:8200/v1/pki/crl"

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -70,6 +70,10 @@ secret_vault_server_key="${vault_server_key_secret_arn}"
 cluster_tag_key="${cluster_tag_key}"
 cluster_tag_value="${cluster_tag_value}"
 ssm_cluster_state_name="${ssm_cluster_state_name}"
+ssm_pki_state_name="${ssm_pki_state_name}"
+ssm_pki_ca_cert_name="${ssm_pki_ca_cert_name}"
+vault_fqdn="${vault_fqdn}"
+vault_iam_role_arn="${vault_iam_role_arn}"
 secret_vault_root_token="${vault_root_token_secret_arn}"
 secret_vault_recovery_keys="${vault_recovery_keys_secret_arn}"
 
@@ -528,6 +532,112 @@ join_cluster() {
 }
 
 # ---------------------------------------------------------------------------
+# Authenticate with Vault using the root token (bootstrap node only)
+# ---------------------------------------------------------------------------
+
+authenticate_vault() {
+  log_info "Authenticating with Vault using root token"
+
+  root_token="$(fetch_secret "$${secret_vault_root_token}")"
+
+  export VAULT_ADDR="https://127.0.0.1:8200"
+  export VAULT_TOKEN="$${root_token}"
+  export VAULT_CACERT="$${tls_ca_file}"
+
+  log_info "Vault authentication configured"
+}
+
+# ---------------------------------------------------------------------------
+# Configure the Vault PKI secrets engine (bootstrap node only)
+# ---------------------------------------------------------------------------
+
+configure_pki_engine() {
+  log_info "Configuring Vault PKI secrets engine"
+
+  # Enable the PKI secrets engine if not already enabled.
+  if ! vault secrets list -format=json | jq -e '."pki/"' >/dev/null 2>&1; then
+    vault secrets enable pki
+  fi
+
+  vault secrets tune -max-lease-ttl=87600h pki
+
+  # Generate root CA with Ed25519 keys. Ed25519 CAs do not support OCSP in
+  # Vault PKI — CRL distribution is configured below instead.
+  vault write -format=json pki/root/generate/internal \
+    common_name="${cluster_tag_value} CA" \
+    ttl=87600h \
+    key_type=ed25519 |
+    jq -r '.data.certificate' >/dev/null
+
+  # Configure CRL and issuing certificate URLs. OCSP is intentionally omitted
+  # — Ed25519 root CAs do not support it in Vault PKI.
+  vault write pki/config/urls \
+    issuing_certificates="https://$${vault_fqdn}:8200/v1/pki/ca" \
+    crl_distribution_points="https://$${vault_fqdn}:8200/v1/pki/crl"
+
+  # Create the vault-server role used by nodes to issue their own TLS certs.
+  vault write pki/roles/vault-server \
+    allowed_domains="$${vault_fqdn}" \
+    allow_bare_domains=true \
+    allow_subdomains=false \
+    max_ttl=720h \
+    key_type=ec \
+    key_bits=384
+
+  # Publish the new CA cert PEM to SSM so follower nodes can fetch it and
+  # trust the new CA before attempting AWS auth. The CA cert is public
+  # material — it is the trust anchor, not the signing key.
+  log_info "Publishing PKI CA cert to SSM"
+  ca_cert_pem="$(vault read -field=certificate pki/cert/ca)"
+  aws ssm put-parameter \
+    --region "$${aws_region}" \
+    --name "$${ssm_pki_ca_cert_name}" \
+    --value "$${ca_cert_pem}" \
+    --overwrite
+
+  log_info "PKI secrets engine configured"
+}
+
+# ---------------------------------------------------------------------------
+# Configure the Vault AWS auth method (bootstrap node only)
+# ---------------------------------------------------------------------------
+
+configure_aws_auth() {
+  log_info "Configuring Vault AWS auth method"
+
+  # Enable the AWS auth method if not already enabled.
+  if ! vault auth list -format=json | jq -e '."aws/"' >/dev/null 2>&1; then
+    vault auth enable aws
+  fi
+
+  # Write a policy granting nodes the ability to issue certs from the
+  # vault-server PKI role. No broader permissions are needed.
+  vault policy write vault-server - <<EOF
+path "pki/issue/vault-server" {
+  capabilities = ["create", "update"]
+}
+EOF
+
+  # Bind the Vault instance IAM role to the vault-server policy.
+  # Nodes authenticate by signing a GetCallerIdentity request with their
+  # instance profile credentials — no shared secrets.
+  vault write auth/aws/role/vault-server \
+    auth_type=iam \
+    bound_iam_principal_arn="$${vault_iam_role_arn}" \
+    policies=vault-server \
+    ttl=1h
+
+  log_info "Writing PKI state: ready"
+  aws ssm put-parameter \
+    --region "$${aws_region}" \
+    --name "$${ssm_pki_state_name}" \
+    --value "ready" \
+    --overwrite
+
+  log_info "AWS auth method configured"
+}
+
+# ---------------------------------------------------------------------------
 # Entrypoint
 # ---------------------------------------------------------------------------
 
@@ -553,6 +663,9 @@ main() {
 
   if is_bootstrap_node; then
     init_cluster
+    authenticate_vault
+    configure_pki_engine
+    configure_aws_auth
   else
     join_cluster
   fi

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -562,8 +562,8 @@ configure_pki_engine() {
   vault secrets tune -max-lease-ttl=87600h pki
 
   # Generate root CA with ECDSA P-384 keys, consistent with the bootstrap
-  # CA and server certs in tls.tf. OCSP is not configured — CRL distribution
-  # is used instead.
+  # CA and server certs in tls.tf. OCSP is not configured (CRL distribution
+  # is used instead).
   vault write -format=json pki/root/generate/internal \
     common_name="${cluster_tag_value} CA" \
     ttl=87600h \


### PR DESCRIPTION
Extends the bootstrap node path with PKI secrets engine and AWS auth method configuration. Follower-side cert issuance and TLS replacement come in the next PR.

New functions:
- `authenticate_vault()`: reads the root token written by `init_cluster()` from Secrets Manager and exports `VAULT_ADDR`, `VAULT_TOKEN`, and `VAULT_CACERT`. Uses the bootstrap CA cert for TLS verification (correct at this point because the PKI cert swap has not yet occurred).
- `configure_pki_engine()`: enables and tunes the PKI secrets engine, generates a root CA using ECDSA P-384 keys, configures CRL distribution URLs, and creates the `vault-server` role allowing nodes to issue their own TLS certs. Immediately after generating the root CA, the CA cert PEM is published to the SSM `vault_pki_ca_cert` parameter so follower nodes can fetch it and establish trust before attempting AWS auth. The CA cert is public material.
- `configure_aws_auth()`: enables the AWS IAM auth method, writes a `vault-server` Vault policy scoped only to `pki/issue/vault-server`, and binds the Vault instance IAM role ARN to that policy. Nodes authenticate by signing an STS `GetCallerIdentity` request with their instance profile credentials (no shared secrets, no token distribution). Writes "ready" to the SSM PKI state flag as its final step so follower nodes can proceed.

Updated `main()` bootstrap path:
- `init_cluster` -> `authenticate_vault` -> `configure_pki_engine` -> `configure_aws_auth`

The follower path (join_cluster) is unchanged in this PR.

Changes to `ec2.tf`:
- `vault_fqdn` and `vault_iam_role_arn` threaded into the `templatefile()` vars map. 
- `vault_fqdn` is used in PKI role `allowed_domains` and CRL URLs. 
- `vault_iam_role_arn` is used to bind the IAM role in the AWS auth method role configuration.