### PR TITLE
refactor: Rename tls.tf to tls_bootstrap.tf and document intent

### DIFF
--- a/tls_bootstrap.tf
+++ b/tls_bootstrap.tf
@@ -1,3 +1,18 @@
+# Bootstrap TLS for the Vault listener.
+#
+# This file generates the self-signed CA and server cert that Vault uses
+# during initial bootstrap, before the Vault PKI secrets engine is mounted.
+# Once PKI is set up, the Vault listener cert is rotated to one issued by
+# Vault itself via Vault Agent, and this file's resources become the
+# trust anchor only — the CA stays, the server cert becomes irrelevant.
+#
+# Algorithm choice: ECDSA P-384 throughout. This is required because the
+# AWS NLB HTTPS health checker rejects Ed25519 in its supported signature
+# algorithms list, and the bootstrap cert has to satisfy every TLS client
+# that handshakes against the listener — including the NLB. Vault PKI
+# leaf certs (issued downstream) can use Ed25519 because they only need
+# to satisfy clients we control.
+
 # CA
 
 resource "tls_private_key" "ca" {
@@ -13,7 +28,7 @@ resource "tls_self_signed_cert" "ca" {
     organization = var.project_name
   }
 
-  validity_period_hours = 8760
+  validity_period_hours = 8760 # 1 year. Rotated by Terraform apply until Vault PKI takes over.
   is_ca_certificate     = true
 
   allowed_uses = [
@@ -51,7 +66,7 @@ resource "tls_locally_signed_cert" "server" {
   ca_private_key_pem = tls_private_key.ca.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.ca.cert_pem
 
-  validity_period_hours = 8760
+  validity_period_hours = 8760 # 1 year. Rotated by Terraform apply until Vault PKI takes over.
 
   allowed_uses = [
     "digital_signature",


### PR DESCRIPTION
Make the bootstrap nature of the TLS configuration explicit. This file generates the CA and server cert that Vault uses during initial bootstrap, before the Vault PKI secrets engine is mounted. Once PKI is in place, the listener cert will be rotated to one issued by Vault itself, and this file's role narrows to "trust anchor only".

Adds a header comment explaining the bootstrap purpose, the ECDSA P-384 algorithm choice (forced by the NLB health checker constraint), and the relationship to future PKI work. Adds inline comments on the `validity_period_hours` fields noting that the 1-year window is a soft deadline for the PKI migration.

Resource names are intentionally left unchanged to avoid cascading reference updates across `secrets.tf` and the `cloud-init` scripts.