### PR TITLE
feat: Add PKI cert issuance and TLS replacement to both node paths

### DIFF
--- a/ssm.tf
+++ b/ssm.tf
@@ -2,7 +2,7 @@ resource "aws_ssm_parameter" "vault_cluster_state" {
   name        = "/${var.project_name}/vault/cluster/state"
   type        = "String"
   value       = "uninitialized"
-  description = "Vault cluster initialization state flag (uninitialized | ready | managed)"
+  description = "Vault cluster initialization state flag (uninitialized | ready)"
 
   lifecycle {
     ignore_changes = [value]

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -748,6 +748,39 @@ replace_node_tls() {
 }
 
 # ---------------------------------------------------------------------------
+# Replace bootstrap CA cert on disk with the PKI CA cert
+# ---------------------------------------------------------------------------
+
+cleanup_bootstrap_tls() {
+  log_info "Replacing bootstrap CA cert with PKI CA cert on disk"
+
+  # Fetch the PKI CA cert from SSM. This was written by configure_pki_engine()
+  # on the bootstrap node and is available to all nodes without a Vault token.
+  pki_ca_cert="$(aws ssm get-parameter \
+    --region "$${aws_region}" \
+    --name "$${ssm_pki_ca_cert_name}" \
+    --query "Parameter.Value" \
+    --output text)"
+
+  # Overwrite the bootstrap CA cert at tls_ca_file. vault.hcl references this
+  # path for leader_ca_cert_file in the retry_join block — it must now trust
+  # the PKI CA, not the bootstrap CA.
+  printf '%s\n' "$${pki_ca_cert}" >"$${tls_ca_file}"
+  chown vault:vault "$${tls_ca_file}"
+  chmod 0640 "$${tls_ca_file}"
+
+  log_info "Bootstrap CA cert replaced with PKI CA cert at $${tls_ca_file}"
+
+  # Remove the temporary PKI CA cert file written by the follower path in
+  # issue_node_cert(), if present.
+  pki_ca_tmp="/opt/vault/tls/pki-ca.crt"
+  if [ -f "$${pki_ca_tmp}" ]; then
+    rm -f "$${pki_ca_tmp}"
+    log_info "Removed temporary PKI CA cert file $${pki_ca_tmp}"
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Entrypoint
 # ---------------------------------------------------------------------------
 
@@ -784,6 +817,7 @@ main() {
   fi
 
   replace_node_tls
+  cleanup_bootstrap_tls
 
   log_info "=== Bootstrap complete ==="
 }

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -10,7 +10,7 @@
 #   - Secrets stored in AWS Secrets Manager
 #   - An EBS data volume attached for Raft storage
 
-# shellcheck disable=SC1083,SC2034,SC2086,SC2154,SC2170,SC2193,SC2269,SC2288
+# shellcheck disable=SC1083,SC2034,SC2086,SC2154,SC2157,SC2170,SC2193,SC2269,SC2288
 # SC1083/SC2288:
 # Terraform's $${var} escape sequence is read by shellcheck as a literal
 # `$${...}` in command position — the sequence is replaced with `$${var}`
@@ -562,8 +562,7 @@ configure_pki_engine() {
   vault secrets tune -max-lease-ttl=87600h pki
 
   # Generate root CA with ECDSA P-384 keys, consistent with the bootstrap
-  # CA and server certs in tls.tf. OCSP is not configured (CRL distribution
-  # is used instead).
+  # CA and server certs in tls.tf.
   vault write -format=json pki/root/generate/internal \
     common_name="${cluster_tag_value} CA" \
     ttl=87600h \

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -703,8 +703,8 @@ issue_node_cert() {
     vault_token="$(vault login \
       -format=json \
       -method=aws \
-      role=vault-server \
-      | jq -r '.auth.client_token')"
+      role=vault-server |
+      jq -r '.auth.client_token')"
     export VAULT_TOKEN="$${vault_token}"
   fi
 

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -515,7 +515,7 @@ join_cluster() {
       --query "Parameter.Value" \
       --output text 2>/dev/null)" || true
 
-    if [ "$${state}" = "ready" ] || [ "$${state}" = "managed" ]; then
+    if [ "$${state}" = "ready" ]; then
       log_info "Cluster state is $${state} — proceeding"
       return 0
     fi

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -641,6 +641,109 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# Wait for PKI bootstrap to complete (follower nodes only)
+# ---------------------------------------------------------------------------
+
+wait_for_pki_ready() {
+  log_info "Waiting for PKI bootstrap to complete"
+
+  attempts=0
+  max_attempts=60
+
+  while true; do
+    state="$(aws ssm get-parameter \
+      --region "$${aws_region}" \
+      --name "$${ssm_pki_state_name}" \
+      --query "Parameter.Value" \
+      --output text 2>/dev/null)" || true
+
+    if [ "$${state}" = "ready" ]; then
+      log_info "PKI bootstrap is ready — proceeding"
+      return 0
+    fi
+
+    attempts=$((attempts + 1))
+    if [ "$${attempts}" -ge "$${max_attempts}" ]; then
+      log_error "PKI bootstrap did not reach ready state after $${max_attempts} attempts"
+      return 1
+    fi
+
+    log_info "PKI state is '$${state}', retrying ($${attempts}/$${max_attempts})"
+    sleep 5
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Issue a PKI-signed TLS certificate for this node
+# ---------------------------------------------------------------------------
+
+issue_node_cert() {
+  log_info "Issuing PKI-signed TLS certificate for this node"
+
+  # Follower nodes need to fetch the new CA cert from SSM and authenticate
+  # via the AWS IAM auth method. The bootstrap node already has VAULT_TOKEN
+  # and VAULT_CACERT set from authenticate_vault().
+  if [ -z "$${VAULT_TOKEN:-}" ]; then
+    log_info "Fetching new PKI CA cert from SSM"
+    new_ca_cert="$(aws ssm get-parameter \
+      --region "$${aws_region}" \
+      --name "$${ssm_pki_ca_cert_name}" \
+      --query "Parameter.Value" \
+      --output text)"
+
+    new_ca_cert_file="/opt/vault/tls/pki-ca.crt"
+    printf '%s\n' "$${new_ca_cert}" >"$${new_ca_cert_file}"
+    chown vault:vault "$${new_ca_cert_file}"
+    chmod 0640 "$${new_ca_cert_file}"
+
+    export VAULT_CACERT="$${new_ca_cert_file}"
+    export VAULT_ADDR="https://127.0.0.1:8200"
+
+    log_info "Authenticating via AWS IAM auth method"
+    vault_token="$(vault login \
+      -format=json \
+      -method=aws \
+      role=vault-server \
+      | jq -r '.auth.client_token')"
+    export VAULT_TOKEN="$${vault_token}"
+  fi
+
+  log_info "Requesting certificate from PKI engine"
+  cert_json="$(vault write -format=json pki/issue/vault-server \
+    common_name="$${vault_fqdn}" \
+    ttl=720h)"
+
+  tmp_cert="/opt/vault/tls/server.crt.tmp"
+  tmp_key="/opt/vault/tls/server.key.tmp"
+
+  printf '%s\n' "$(printf '%s' "$${cert_json}" | jq -r '.data.certificate')" \
+    >"$${tmp_cert}"
+  printf '%s\n' "$(printf '%s' "$${cert_json}" | jq -r '.data.private_key')" \
+    >"$${tmp_key}"
+
+  chown vault:vault "$${tmp_cert}" "$${tmp_key}"
+  chmod 0640 "$${tmp_cert}" "$${tmp_key}"
+
+  # Atomic move to final paths — vault.hcl already references these.
+  mv "$${tmp_cert}" "$${tls_cert_file}"
+  mv "$${tmp_key}" "$${tls_key_file}"
+
+  log_info "PKI-signed certificate written to $${tls_cert_file}"
+}
+
+# ---------------------------------------------------------------------------
+# Reload the Vault TLS listener with the newly issued certificate
+# ---------------------------------------------------------------------------
+
+replace_node_tls() {
+  log_info "Reloading Vault TLS listener with PKI-signed certificate"
+
+  systemctl kill -s HUP vault
+
+  log_info "Vault TLS listener reloaded"
+}
+
+# ---------------------------------------------------------------------------
 # Entrypoint
 # ---------------------------------------------------------------------------
 
@@ -669,9 +772,14 @@ main() {
     authenticate_vault
     configure_pki_engine
     configure_aws_auth
+    issue_node_cert
   else
     join_cluster
+    wait_for_pki_ready
+    issue_node_cert
   fi
+
+  replace_node_tls
 
   log_info "=== Bootstrap complete ==="
 }

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -690,13 +690,18 @@ issue_node_cert() {
       --query "Parameter.Value" \
       --output text)"
 
+    # Write the new PKI CA cert to disk for use by clients connecting
+    # to this node after the TLS swap in replace_node_tls(). It is not
+    # used for Vault API calls here — this node's listener is still
+    # presenting the bootstrap cert until the SIGHUP, so VAULT_CACERT
+    # must continue to point at the bootstrap CA.
     new_ca_cert_file="/opt/vault/tls/pki-ca.crt"
     printf '%s\n' "$${new_ca_cert}" >"$${new_ca_cert_file}"
     chown vault:vault "$${new_ca_cert_file}"
     chmod 0640 "$${new_ca_cert_file}"
 
-    export VAULT_CACERT="$${new_ca_cert_file}"
     export VAULT_ADDR="https://127.0.0.1:8200"
+    export VAULT_CACERT="$${tls_ca_file}"
 
     log_info "Authenticating via AWS IAM auth method"
     vault_token="$(vault login \


### PR DESCRIPTION
Completes the PKI bootstrap DAG. All three nodes end this script serving TLS with a Vault PKI-issued certificate and trusting the PKI CA as their Raft peer-discovery trust anchor.

New functions:
- `wait_for_pki_ready()`: follower-side counterpart to the bootstrap node's `configure_aws_auth()`. 
  - Polls the SSM PKI state flag until "ready", then unblocks so the follower can proceed to cert issuance. 
  - Same retry pattern as `join_cluster()`, 60 attempts at 5-second intervals (5-minute ceiling).
- `issue_node_cert()`: issues a PKI-signed TLS cert from the `vault-server` role. 
  - The two paths through this function diverge on whether `VAULT_TOKEN` is already set. 
  - The bootstrap node has a token from `authenticate_vault()` and `VAULT_CACERT` pointing at the bootstrap CA (it issues directly). 
  - Follower nodes have neither: they fetch the new CA cert PEM from SSM (published by `configure_pki_engine()`) and write it to `/opt/vault/tls/pki-ca.crt`, then authenticate via the AWS IAM auth method to obtain a short-lived token before issuing. 
  - `VAULT_CACERT` stays pointed at the bootstrap CA throughout the login and issue calls because the follower's own listener is still presenting the bootstrap cert at that point (the PKI cert swap does not happen until `replace_node_tls()` sends `SIGHUP`). 
  - Both paths write the issued cert and key to temporary files then atomically move them to the paths already referenced in `vault.hcl`, avoiding a window where cert and key are mismatched.
- `replace_node_tls()`: sends `SIGHUP` to the Vault process via `systemctl kill` so the TLS listener reloads the newly written cert and key without a full service restart. 
  - Called outside the if/else block because it is identical on both paths.
- `cleanup_bootstrap_tls()`: after the `SIGHUP`, the listener is serving a PKI-issued cert but `$${tls_ca_file}` still contains the bootstrap CA. 
  - `vault.hcl` references that path as `leader_ca_cert_file` in the `retry_join` block (the leader now presents a PKI-signed cert, so this file must trust the PKI CA or Raft peer discovery will fail on the next retry cycle). 
  - Fetches the PKI CA cert PEM from SSM, overwrites `$${tls_ca_file}` in place (`vault.hcl` path unchanged), and removes the temporary `/opt/vault/tls/pki-ca.crt` file written by the follower path. 
  - No additional `SIGHUP` needed (Vault reads `leader_ca_cert_file` dynamically and the listener CA is inert with client certs disabled).

After this PR every node exits `cloud-init` with no bootstrap TLS material remaining on disk and all three paths have been replaced with PKI-issued material.