### PR TITLE
fix: Restrict vault-server PKI role to serverAuth extended key usage

### DIFF
--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -584,7 +584,8 @@ configure_pki_engine() {
     allow_subdomains=false \
     max_ttl=720h \
     key_type=ec \
-    key_bits=384
+    key_bits=384 \
+    ext_key_usage=serverAuth
 
   # Publish the new CA cert PEM to SSM so follower nodes can fetch it and
   # trust the new CA before attempting AWS auth. The CA cert is public


### PR DESCRIPTION
Vault PKI role defaults include both `serverAuth` and `clientAuth` in the Extended Key Usage extension. Observed in the issued cert:
> `Extended Key Usages: Server Authentication, Client Authentication`

Vault server TLS certs have no need for `clientAuth`. Adding `ext_key_usage=serverAuth` to the role definition restricts issued certs to server authentication only, following least-privilege for certificate key usage.

One-line change to the `vault write pki/roles/vault-server` call in `configure_pki_engine()`.

No other changes.