### PR TITLE
feat: Install Vault via binary download with GPG/SHA256 verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,11 +136,11 @@ module "vault" {
 | <a name="input_vault_api_allowed_cidrs"></a> [vault\_api\_allowed\_cidrs](#input\_vault\_api\_allowed\_cidrs) | CIDR blocks allowed to reach the Vault API (port 8200) from outside the VPC. Only effective when nlb\_internal is false. | `list(string)` | `[]` | no |
 | <a name="input_vault_ebs_volume_size"></a> [vault\_ebs\_volume\_size](#input\_vault\_ebs\_volume\_size) | Size in GiB of the EBS volume for Vault Raft storage. | `number` | `100` | no |
 | <a name="input_vault_license"></a> [vault\_license](#input\_vault\_license) | Vault Enterprise license string. | `string` | n/a | yes |
-| <a name="input_vault_package_version"></a> [vault\_package\_version](#input\_vault\_package\_version) | Vault Enterprise release version (e.g., 1.21.4+ent). Do not include the apt -1 suffix. | `string` | `"1.21.4+ent"` | no |
 | <a name="input_vault_server_instance_type"></a> [vault\_server\_instance\_type](#input\_vault\_server\_instance\_type) | EC2 instance type for Vault server nodes. | `string` | `"m5.large"` | no |
 | <a name="input_vault_snapshot_interval"></a> [vault\_snapshot\_interval](#input\_vault\_snapshot\_interval) | Seconds between automated Raft snapshots. | `number` | `3600` | no |
 | <a name="input_vault_snapshot_retain"></a> [vault\_snapshot\_retain](#input\_vault\_snapshot\_retain) | Number of automated Raft snapshots to retain in S3. | `number` | `72` | no |
 | <a name="input_vault_subdomain"></a> [vault\_subdomain](#input\_vault\_subdomain) | Subdomain for the Vault DNS record. | `string` | `"vault"` | no |
+| <a name="input_vault_version"></a> [vault\_version](#input\_vault\_version) | Vault Enterprise release version (e.g., 1.21.4+ent). Do not include the apt -1 suffix. | `string` | `"1.21.4+ent"` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR block for the VPC. | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_vpc_private_subnets"></a> [vpc\_private\_subnets](#input\_vpc\_private\_subnets) | Private subnet CIDR blocks. | `list(string)` | <pre>[<br/>  "10.0.1.0/24",<br/>  "10.0.2.0/24",<br/>  "10.0.3.0/24"<br/>]</pre> | no |
 | <a name="input_vpc_public_subnets"></a> [vpc\_public\_subnets](#input\_vpc\_public\_subnets) | Public subnet CIDR blocks. | `list(string)` | <pre>[<br/>  "10.0.101.0/24",<br/>  "10.0.102.0/24",<br/>  "10.0.103.0/24"<br/>]</pre> | no |

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ module "vault" {
 | <a name="input_vault_api_allowed_cidrs"></a> [vault\_api\_allowed\_cidrs](#input\_vault\_api\_allowed\_cidrs) | CIDR blocks allowed to reach the Vault API (port 8200) from outside the VPC. Only effective when nlb\_internal is false. | `list(string)` | `[]` | no |
 | <a name="input_vault_ebs_volume_size"></a> [vault\_ebs\_volume\_size](#input\_vault\_ebs\_volume\_size) | Size in GiB of the EBS volume for Vault Raft storage. | `number` | `100` | no |
 | <a name="input_vault_license"></a> [vault\_license](#input\_vault\_license) | Vault Enterprise license string. | `string` | n/a | yes |
-| <a name="input_vault_package_version"></a> [vault\_package\_version](#input\_vault\_package\_version) | Vault Enterprise apt package version to install (e.g., 1.21.4+ent-1). | `string` | `"1.21.4+ent-1"` | no |
+| <a name="input_vault_package_version"></a> [vault\_package\_version](#input\_vault\_package\_version) | Vault Enterprise release version (e.g., 1.21.4+ent). Do not include the apt -1 suffix. | `string` | `"1.21.4+ent"` | no |
 | <a name="input_vault_server_instance_type"></a> [vault\_server\_instance\_type](#input\_vault\_server\_instance\_type) | EC2 instance type for Vault server nodes. | `string` | `"m5.large"` | no |
 | <a name="input_vault_snapshot_interval"></a> [vault\_snapshot\_interval](#input\_vault\_snapshot\_interval) | Seconds between automated Raft snapshots. | `number` | `3600` | no |
 | <a name="input_vault_snapshot_retain"></a> [vault\_snapshot\_retain](#input\_vault\_snapshot\_retain) | Number of automated Raft snapshots to retain in S3. | `number` | `72` | no |

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ module "vault" {
 | <a name="input_vault_snapshot_interval"></a> [vault\_snapshot\_interval](#input\_vault\_snapshot\_interval) | Seconds between automated Raft snapshots. | `number` | `3600` | no |
 | <a name="input_vault_snapshot_retain"></a> [vault\_snapshot\_retain](#input\_vault\_snapshot\_retain) | Number of automated Raft snapshots to retain in S3. | `number` | `72` | no |
 | <a name="input_vault_subdomain"></a> [vault\_subdomain](#input\_vault\_subdomain) | Subdomain for the Vault DNS record. | `string` | `"vault"` | no |
-| <a name="input_vault_version"></a> [vault\_version](#input\_vault\_version) | Vault Enterprise release version (e.g., 1.21.4+ent). Do not include the apt -1 suffix. | `string` | `"1.21.4+ent"` | no |
+| <a name="input_vault_version"></a> [vault\_version](#input\_vault\_version) | Vault Enterprise release version (e.g., 1.21.4+ent). | `string` | `"1.21.4+ent"` | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | CIDR block for the VPC. | `string` | `"10.0.0.0/16"` | no |
 | <a name="input_vpc_private_subnets"></a> [vpc\_private\_subnets](#input\_vpc\_private\_subnets) | Private subnet CIDR blocks. | `list(string)` | <pre>[<br/>  "10.0.1.0/24",<br/>  "10.0.2.0/24",<br/>  "10.0.3.0/24"<br/>]</pre> | no |
 | <a name="input_vpc_public_subnets"></a> [vpc\_public\_subnets](#input\_vpc\_public\_subnets) | Public subnet CIDR blocks. | `list(string)` | <pre>[<br/>  "10.0.101.0/24",<br/>  "10.0.102.0/24",<br/>  "10.0.103.0/24"<br/>]</pre> | no |

--- a/ec2.tf
+++ b/ec2.tf
@@ -64,7 +64,9 @@ resource "aws_instance" "vault" {
       cluster_tag_value = local.cluster_tag_value
     })
 
-    config_snapshot_json = local.config_snapshot_json
+    config_vault_service          = local.config_vault_service
+    config_vault_service_override = local.config_vault_service_override
+    config_snapshot_json          = local.config_snapshot_json
   }))
 
   tags = merge(var.common_tags, {

--- a/ec2.tf
+++ b/ec2.tf
@@ -36,7 +36,7 @@ resource "aws_instance" "vault" {
   }
 
   user_data_base64 = base64gzip(templatefile("${path.module}/templates/cloud-init.sh.tftpl", {
-    vault_version                = var.vault_package_version
+    vault_version                = var.vault_version
     region                       = data.aws_region.current.region
     ebs_device_name              = local.ebs_device_name
     vault_license_secret_arn     = aws_secretsmanager_secret.vault_license.arn

--- a/files/vault.service
+++ b/files/vault.service
@@ -1,0 +1,32 @@
+[Unit]
+Description=HashiCorp Vault - A Secret Management Tool
+Documentation=https://developer.hashicorp.com/vault/docs
+Requires=network-online.target
+After=network-online.target
+ConditionFileNotEmpty=/etc/vault.d/vault.hcl
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+[Service]
+User=vault
+Group=vault
+ProtectSystem=full
+ProtectHome=read-only
+PrivateTmp=yes
+PrivateDevices=yes
+SecureBits=keep-caps
+AmbientCapabilities=CAP_IPC_LOCK
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
+NoNewPrivileges=yes
+ExecStart=/usr/bin/vault server -config=/etc/vault.d/vault.hcl
+ExecReload=/bin/kill --signal HUP $MAINPID
+KillMode=process
+KillSignal=SIGINT
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+LimitNOFILE=65536
+LimitMEMLOCK=infinity
+
+[Install]
+WantedBy=multi-user.target

--- a/files/vault.service.d-override.conf
+++ b/files/vault.service.d-override.conf
@@ -1,0 +1,2 @@
+[Service]
+Environment="VAULT_ENABLE_FILE_PERMISSIONS_CHECK=true"

--- a/locals.tf
+++ b/locals.tf
@@ -6,6 +6,9 @@ locals {
   cluster_tag_value = var.project_name
   ebs_device_name   = "/dev/xvdf" # AWS convention for the first additional EBS volume
 
+  config_vault_service          = file("${path.module}/files/vault.service")
+  config_vault_service_override = file("${path.module}/files/vault.service.d-override.conf")
+
   config_snapshot_json = templatefile("${path.module}/templates/snapshot.json.tftpl", {
     aws_s3_bucket = aws_s3_bucket.vault_snapshots.id
     aws_s3_region = data.aws_region.current.region

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -331,9 +331,9 @@ install_vault() {
   tmp_dir="$(mktemp -d)"
   trap 'rm -rf "$${tmp_dir}"' EXIT
 
-  curl -fsSL -o "$${tmp_dir}" "$${base_url}/$${zip_file}"
-  curl -fsSL -o "$${tmp_dir}" "$${base_url}/$${sums_file}"
-  curl -fsSL -o "$${tmp_dir}" "$${base_url}/$${sig_file}"
+  curl -fsSL -o "$${tmp_dir}/$${zip_file}" "$${base_url}/$${zip_file}"
+  curl -fsSL -o "$${tmp_dir}/$${sums_file}" "$${base_url}/$${sums_file}"
+  curl -fsSL -o "$${tmp_dir}/$${sig_file}" "$${base_url}/$${sig_file}"
 
   # GPG signature verification — isolated keyring to avoid polluting the system
   export GNUPGHOME="$${tmp_dir}/.gnupg"

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -346,7 +346,7 @@ install_vault() {
   gpg --import "$${tmp_dir}/hashicorp.asc"
 
   log_info "Verifying GPG signature"
-  gpg --verify "$${tmp_dir}/$${sig_file}" "$${tmp_dir}/$${sums_file}"
+  gpg --trust-model=always --verify "$${tmp_dir}/$${sig_file}" "$${tmp_dir}/$${sums_file}"
 
   # SHA256 checksum verification
   log_info "Verifying SHA256 checksum"

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -344,10 +344,9 @@ install_vault() {
   wget -q -O "$${tmp_dir}/hashicorp.asc" \
     https://www.hashicorp.com/.well-known/pgp-key.txt
   gpg --import "$${tmp_dir}/hashicorp.asc"
-  printf '%s\n' "C874011F0AB405110D02105534365D9472D7468F:5:" | gpg --import-ownertrust
 
   log_info "Verifying GPG signature"
-  gpg --verify "$${tmp_dir}/$${sig_file}" "$${tmp_dir}/$${sums_file}"
+  gpg --trust-model direct --verify "$${tmp_dir}/$${sig_file}" "$${tmp_dir}/$${sums_file}"
 
   # SHA256 checksum verification
   log_info "Verifying SHA256 checksum"

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -344,7 +344,7 @@ install_vault() {
   wget -q -O "$${tmp_dir}/hashicorp.asc" \
     https://www.hashicorp.com/.well-known/pgp-key.txt
   gpg --import "$${tmp_dir}/hashicorp.asc"
-  printf 'C874011F0AB405110D02105534365D9472D7468F:5:' | gpg --import-ownertrust
+  printf '%s\n' "C874011F0AB405110D02105534365D9472D7468F:5:" | gpg --import-ownertrust
 
   log_info "Verifying GPG signature"
   gpg --verify "$${tmp_dir}/$${sig_file}" "$${tmp_dir}/$${sums_file}"

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -358,55 +358,21 @@ install_vault() {
 }
 
 # ---------------------------------------------------------------------------
-# Generate the systemd unit file for Vault
+# Write the Vault systemd unit file and drop-in override
 # ---------------------------------------------------------------------------
 
-write_systemd_unit() {
-  log_info "Writing Vault systemd unit file"
+write_vault_systemd_unit() {
+  log_info "Writing Vault systemd unit"
 
-  cat >/etc/systemd/system/vault.service <<'UNIT'
-[Unit]
-Description=HashiCorp Vault - A Secret Management Tool
-Documentation=https://developer.hashicorp.com/vault/docs
-Requires=network-online.target
-After=network-online.target
-ConditionFileNotEmpty=/etc/vault.d/vault.hcl
-StartLimitIntervalSec=60
-StartLimitBurst=3
+  cat >/etc/systemd/system/vault.service <<'EOF'
+${config_vault_service}
+EOF
 
-[Service]
-User=vault
-Group=vault
-ProtectSystem=full
-ProtectHome=read-only
-PrivateTmp=yes
-PrivateDevices=yes
-SecureBits=keep-caps
-AmbientCapabilities=CAP_IPC_LOCK
-CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
-NoNewPrivileges=yes
-ExecStart=/usr/bin/vault server -config=/etc/vault.d/vault.hcl
-ExecReload=/bin/kill --signal HUP $MAINPID
-KillMode=process
-KillSignal=SIGINT
-Restart=on-failure
-RestartSec=5
-TimeoutStopSec=30
-LimitNOFILE=65536
-LimitMEMLOCK=infinity
-
-[Install]
-WantedBy=multi-user.target
-UNIT
-
-  # Drop-in override for file permissions check
   mkdir -p /etc/systemd/system/vault.service.d
-  cat >/etc/systemd/system/vault.service.d/override.conf <<'OVERRIDE'
-[Service]
-Environment="VAULT_ENABLE_FILE_PERMISSIONS_CHECK=true"
-OVERRIDE
-
-  log_info "Vault systemd unit file written"
+  cat >/etc/systemd/system/vault.service.d/override.conf <<'EOF'
+${config_vault_service_override}
+EOF
+  chmod 0600 /etc/systemd/system/vault.service.d/override.conf
 }
 
 # ---------------------------------------------------------------------------
@@ -910,7 +876,7 @@ main() {
   create_vault_user
   mount_data_volume
   install_vault
-  write_systemd_unit
+  write_vault_systemd_unit
 
   write_secrets
   write_vault_config "$${private_ip}"

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -344,9 +344,10 @@ install_vault() {
   wget -q -O "$${tmp_dir}/hashicorp.asc" \
     https://www.hashicorp.com/.well-known/pgp-key.txt
   gpg --import "$${tmp_dir}/hashicorp.asc"
+  echo "C874011F0AB405110D02105534365D9472D7468F:5:" | gpg --import-ownertrust
 
   log_info "Verifying GPG signature"
-  gpg --trust-model=always --verify "$${tmp_dir}/$${sig_file}" "$${tmp_dir}/$${sums_file}"
+  gpg --verify "$${tmp_dir}/$${sig_file}" "$${tmp_dir}/$${sums_file}"
 
   # SHA256 checksum verification
   log_info "Verifying SHA256 checksum"

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -308,7 +308,7 @@ create_vault_user() {
 install_vault() {
   log_info "Installing Vault Enterprise $${vault_version}"
 
-  apt-get -yq install gnupg wget >/dev/null
+  apt-get -yq install gnupg >/dev/null
 
   # Detect architecture
   machine="$(uname -m)"
@@ -331,22 +331,22 @@ install_vault() {
   tmp_dir="$(mktemp -d)"
   trap 'rm -rf "$${tmp_dir}"' EXIT
 
-  wget -q -P "$${tmp_dir}" \
-    "$${base_url}/$${zip_file}" \
-    "$${base_url}/$${sums_file}" \
-    "$${base_url}/$${sig_file}"
+  curl -fsSL -o "$${tmp_dir}" "$${base_url}/$${zip_file}"
+  curl -fsSL -o "$${tmp_dir}" "$${base_url}/$${sums_file}"
+  curl -fsSL -o "$${tmp_dir}" "$${base_url}/$${sig_file}"
 
   # GPG signature verification — isolated keyring to avoid polluting the system
   export GNUPGHOME="$${tmp_dir}/.gnupg"
   mkdir -p "$${GNUPGHOME}"
   chmod 0700 "$${GNUPGHOME}"
 
-  wget -q -O "$${tmp_dir}/hashicorp.asc" \
+  curl -fsSL -o "$${tmp_dir}/hashicorp.asc" \
     https://www.hashicorp.com/.well-known/pgp-key.txt
-  gpg --import "$${tmp_dir}/hashicorp.asc"
+  gpg --quiet --import "$${tmp_dir}/hashicorp.asc"
+  printf '%s\n' "C874011F0AB405110D02105534365D9472D7468F:6:" | gpg --quiet --import-ownertrust
 
   log_info "Verifying GPG signature"
-  gpg --trust-model direct --verify "$${tmp_dir}/$${sig_file}" "$${tmp_dir}/$${sums_file}"
+  gpg --quiet --verify "$${tmp_dir}/$${sig_file}" "$${tmp_dir}/$${sums_file}"
 
   # SHA256 checksum verification
   log_info "Verifying SHA256 checksum"

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -10,7 +10,7 @@
 #   - Secrets stored in AWS Secrets Manager
 #   - An EBS data volume attached for Raft storage
 
-# shellcheck disable=SC1083,SC2034,SC2086,SC2154,SC2157,SC2170,SC2193,SC2269,SC2288
+# shellcheck disable=SC1083,SC2034,SC2086,SC2154,SC2157,SC2170,SC2193,SC2195,SC2269,SC2288
 # SC1083/SC2288:
 # Terraform's $${var} escape sequence is read by shellcheck as a literal
 # `$${...}` in command position — the sequence is replaced with `$${var}`
@@ -26,6 +26,9 @@
 # SC2193:
 # curl -w '%%{http_code}' returns runtime HTTP status codes; shellcheck
 # reads the literal format string and cannot see the comparison is valid.
+# SC2195:
+# case "$${machine}" patterns are valid at runtime — shellcheck sees the
+# Terraform escape as a literal and incorrectly flags the case arms.
 # SC2269:
 # vault_version="${vault_version}" is not self-assignment — the RHS is a
 # Terraform interpolation replaced at plan time.
@@ -193,9 +196,7 @@ prepare_system() {
 
   apt-get -yq update >/dev/null
   apt-get -yq install \
-    awscli jq unzip gnupg lsb-release nvme-cli amazon-ec2-utils chrony >/dev/null
-
-  # The vault-enterprise package creates the vault user, so no useradd here.
+    awscli jq unzip nvme-cli amazon-ec2-utils chrony >/dev/null
 }
 
 # ---------------------------------------------------------------------------
@@ -283,20 +284,129 @@ mount_data_volume() {
 }
 
 # ---------------------------------------------------------------------------
-# Install Vault Enterprise
+# Create the vault system user and group
+# ---------------------------------------------------------------------------
+
+create_vault_user() {
+  log_info "Creating vault system user"
+
+  groupadd --system vault
+  useradd --system -g vault -d /etc/vault.d -s /bin/false vault
+}
+
+# ---------------------------------------------------------------------------
+# Install Vault Enterprise — binary download with GPG + SHA256 verification
 # ---------------------------------------------------------------------------
 
 install_vault() {
   log_info "Installing Vault Enterprise $${vault_version}"
 
-  curl -fsSL https://apt.releases.hashicorp.com/gpg |
-    gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+  apt-get -yq install gnupg wget >/dev/null
 
-  echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
-    >/etc/apt/sources.list.d/hashicorp.list
+  # Detect architecture
+  machine="$(uname -m)"
+  case "$${machine}" in
+    x86_64)  arch="amd64" ;;
+    aarch64) arch="arm64" ;;
+    *)
+      log_error "Unsupported architecture: $${machine}"
+      return 1
+      ;;
+  esac
+  log_info "Detected architecture: $${arch}" >&2
 
-  apt-get -yq update >/dev/null
-  apt-get -yq install vault-enterprise=$${vault_version} >/dev/null
+  base_url="https://releases.hashicorp.com/vault/${vault_version}"
+  zip_file="vault_${vault_version}_linux_$${arch}.zip"
+  sums_file="vault_${vault_version}_SHA256SUMS"
+  sig_file="vault_${vault_version}_SHA256SUMS.sig"
+
+  # Download release artifacts into an isolated temp directory
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$${tmp_dir}"' EXIT
+
+  wget -q -P "$${tmp_dir}" \
+    "$${base_url}/$${zip_file}" \
+    "$${base_url}/$${sums_file}" \
+    "$${base_url}/$${sig_file}"
+
+  # GPG signature verification — isolated keyring to avoid polluting the system
+  export GNUPGHOME="$${tmp_dir}/.gnupg"
+  mkdir -p "$${GNUPGHOME}"
+  chmod 0700 "$${GNUPGHOME}"
+
+  wget -q -O "$${tmp_dir}/hashicorp.asc" \
+    https://www.hashicorp.com/.well-known/pgp-key.txt
+  gpg --import "$${tmp_dir}/hashicorp.asc"
+
+  log_info "Verifying GPG signature"
+  gpg --verify "$${tmp_dir}/$${sig_file}" "$${tmp_dir}/$${sums_file}"
+
+  # SHA256 checksum verification
+  log_info "Verifying SHA256 checksum"
+  cd "$${tmp_dir}"
+  sha256sum -c --ignore-missing "$${sums_file}"
+  cd /
+
+  # Install the binary
+  unzip -o "$${tmp_dir}/$${zip_file}" -d "$${tmp_dir}"
+  mv "$${tmp_dir}/vault" /usr/bin/vault
+  chown root:root /usr/bin/vault
+  chmod 0755 /usr/bin/vault
+  ln -sf /usr/bin/vault /usr/local/bin/vault
+
+  log_info "Vault Enterprise $${vault_version} installed"
+}
+
+# ---------------------------------------------------------------------------
+# Generate the systemd unit file for Vault
+# ---------------------------------------------------------------------------
+
+write_systemd_unit() {
+  log_info "Writing Vault systemd unit file"
+
+  cat >/etc/systemd/system/vault.service <<'UNIT'
+[Unit]
+Description=HashiCorp Vault - A Secret Management Tool
+Documentation=https://developer.hashicorp.com/vault/docs
+Requires=network-online.target
+After=network-online.target
+ConditionFileNotEmpty=/etc/vault.d/vault.hcl
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+[Service]
+User=vault
+Group=vault
+ProtectSystem=full
+ProtectHome=read-only
+PrivateTmp=yes
+PrivateDevices=yes
+SecureBits=keep-caps
+AmbientCapabilities=CAP_IPC_LOCK
+CapabilityBoundingSet=CAP_SYSLOG CAP_IPC_LOCK
+NoNewPrivileges=yes
+ExecStart=/usr/bin/vault server -config=/etc/vault.d/vault.hcl
+ExecReload=/bin/kill --signal HUP $MAINPID
+KillMode=process
+KillSignal=SIGINT
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+LimitNOFILE=65536
+LimitMEMLOCK=infinity
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+  # Drop-in override for file permissions check
+  mkdir -p /etc/systemd/system/vault.service.d
+  cat >/etc/systemd/system/vault.service.d/override.conf <<'OVERRIDE'
+[Service]
+Environment="VAULT_ENABLE_FILE_PERMISSIONS_CHECK=true"
+OVERRIDE
+
+  log_info "Vault systemd unit file written"
 }
 
 # ---------------------------------------------------------------------------
@@ -369,6 +479,8 @@ EOF
 
 start_services() {
   log_info "Enabling the Vault service"
+
+  systemctl daemon-reload
 
   # Vault starts sealed; no health-check loop here because /v1/sys/health
   # returns non-2xx until init/unseal is performed by an operator.
@@ -795,8 +907,10 @@ main() {
 
   prepare_system
   configure_time
+  create_vault_user
   mount_data_volume
   install_vault
+  write_systemd_unit
 
   write_secrets
   write_vault_config "$${private_ip}"

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -344,7 +344,7 @@ install_vault() {
   wget -q -O "$${tmp_dir}/hashicorp.asc" \
     https://www.hashicorp.com/.well-known/pgp-key.txt
   gpg --import "$${tmp_dir}/hashicorp.asc"
-  echo "C874011F0AB405110D02105534365D9472D7468F:5:" | gpg --import-ownertrust
+  printf 'C874011F0AB405110D02105534365D9472D7468F:5:' | gpg --import-ownertrust
 
   log_info "Verifying GPG signature"
   gpg --verify "$${tmp_dir}/$${sig_file}" "$${tmp_dir}/$${sums_file}"

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -292,6 +292,13 @@ create_vault_user() {
 
   groupadd --system vault
   useradd --system -g vault -d /etc/vault.d -s /bin/false vault
+
+  mkdir -p /etc/vault.d/tls
+  mkdir -p /opt/vault/tls
+  mkdir -p /opt/vault/data
+
+  chown -R vault:vault /etc/vault.d /opt/vault
+  chmod 750 /etc/vault.d /opt/vault
 }
 
 # ---------------------------------------------------------------------------
@@ -306,7 +313,7 @@ install_vault() {
   # Detect architecture
   machine="$(uname -m)"
   case "$${machine}" in
-    x86_64)  arch="amd64" ;;
+    x86_64) arch="amd64" ;;
     aarch64) arch="arm64" ;;
     *)
       log_error "Unsupported architecture: $${machine}"

--- a/variables.tf
+++ b/variables.tf
@@ -125,12 +125,12 @@ variable "vault_subdomain" {
 
 variable "vault_package_version" {
   type        = string
-  description = "Vault Enterprise apt package version to install (e.g., 1.21.4+ent-1)."
-  default     = "1.21.4+ent-1"
+  description = "Vault Enterprise release version (e.g., 1.21.4+ent). Do not include the apt -1 suffix."
+  default     = "1.21.4+ent"
 
   validation {
-    condition     = can(regex("^\\d+\\.\\d+\\.\\d+\\+ent(\\.hsm)?(\\.fips1403)?-\\d+$", var.vault_package_version))
-    error_message = "Must be a valid Vault Enterprise package version (e.g., 1.21.4+ent-1, 1.21.4+ent.hsm.fips1403-1)."
+    condition     = can(regex("^\\d+\\.\\d+\\.\\d+\\+ent(\\.hsm)?(\\.fips1402)?$", var.vault_package_version))
+    error_message = "Must be a valid Vault Enterprise release version (e.g., 1.21.4+ent, 1.21.4+ent.hsm, 1.21.4+ent.fips1402)."
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -123,13 +123,13 @@ variable "vault_subdomain" {
   default     = "vault"
 }
 
-variable "vault_package_version" {
+variable "vault_version" {
   type        = string
   description = "Vault Enterprise release version (e.g., 1.21.4+ent). Do not include the apt -1 suffix."
   default     = "1.21.4+ent"
 
   validation {
-    condition     = can(regex("^\\d+\\.\\d+\\.\\d+\\+ent(\\.hsm)?(\\.fips1402)?$", var.vault_package_version))
+    condition     = can(regex("^\\d+\\.\\d+\\.\\d+\\+ent(\\.hsm)?(\\.fips1402)?$", var.vault_version))
     error_message = "Must be a valid Vault Enterprise release version (e.g., 1.21.4+ent, 1.21.4+ent.hsm, 1.21.4+ent.fips1402)."
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -125,7 +125,7 @@ variable "vault_subdomain" {
 
 variable "vault_version" {
   type        = string
-  description = "Vault Enterprise release version (e.g., 1.21.4+ent). Do not include the apt -1 suffix."
+  description = "Vault Enterprise release version (e.g., 1.21.4+ent)."
   default     = "1.21.4+ent"
 
   validation {


### PR DESCRIPTION
- Replace APT-based Vault Enterprise install with direct binary download from releases.hashicorp.com
- Add GPG signature verification using HashiCorp's public key in an isolated GNUPGHOME
- Add SHA256 checksum verification via sha256sum
- Add `create_vault_user` function (groupadd/useradd) since the deb package no longer creates it
- Add `write_systemd_unit` function with hardened systemd unit file and `VAULT_ENABLE_FILE_PERMISSIONS_CHECK` drop-in override
- Add `systemctl daemon-reload` to `start_services` before enabling the unit
- Move `gnupg` from `prepare_system` to `install_vault` where it is actually needed; drop `lsb-release` (no longer used)
- Add SC2195 to shellcheck disable list (false positive from Terraform `$${var}` escaping in case patterns)