### PR TITLE
feat: Add Vault Agent static configuration files

### DIFF
--- a/files/vault-agent.hcl
+++ b/files/vault-agent.hcl
@@ -1,0 +1,35 @@
+pid_file = "/opt/vault/agent/agent.pid"
+
+vault {
+  address = "https://127.0.0.1:8200"
+  ca_cert = "/opt/vault/tls/ca.crt"
+}
+
+auto_auth {
+  method "aws" {
+    mount_path = "auth/aws"
+    config = {
+      type = "iam"
+      role = "vault-server"
+    }
+  }
+
+  sink "file" {
+    config = {
+      path = "/opt/vault/agent/token"
+    }
+  }
+}
+
+template {
+  source      = "/etc/vault-agent/server.crt.ctmpl"
+  destination = "/opt/vault/tls/server.crt"
+  perms       = "0640"
+  command     = "systemctl kill -s HUP vault.service"
+}
+
+template {
+  source      = "/etc/vault-agent/server.key.ctmpl"
+  destination = "/opt/vault/tls/server.key"
+  perms       = "0640"
+}

--- a/files/vault-agent.service
+++ b/files/vault-agent.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=HashiCorp Vault Agent
+Documentation=https://developer.hashicorp.com/vault/docs/agent-and-proxy/agent
+Requires=vault.service
+After=vault.service
+ConditionFileNotEmpty=/etc/vault-agent/agent.hcl
+StartLimitIntervalSec=60
+StartLimitBurst=3
+
+[Service]
+Type=notify
+User=vault
+Group=vault
+ProtectSystem=full
+ProtectHome=read-only
+PrivateTmp=yes
+PrivateDevices=yes
+SecureBits=keep-caps
+NoNewPrivileges=yes
+ExecStart=/usr/bin/vault agent -config=/etc/vault-agent/agent.hcl
+ExecReload=/bin/kill --signal HUP $MAINPID
+KillMode=process
+KillSignal=SIGINT
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/files/vault-agent/server.crt.ctmpl
+++ b/files/vault-agent/server.crt.ctmpl
@@ -1,0 +1,4 @@
+{{ with pkiCert "pki/issue/vault-server" "common_name=VAULT_FQDN_PLACEHOLDER" "ttl=168h" }}
+{{ .Cert }}
+{{ .CA }}
+{{ end }}

--- a/files/vault-agent/server.key.ctmpl
+++ b/files/vault-agent/server.key.ctmpl
@@ -1,0 +1,3 @@
+{{ with pkiCert "pki/issue/vault-server" "common_name=VAULT_FQDN_PLACEHOLDER" "ttl=168h" }}
+{{ .Key }}
+{{ end }}

--- a/locals.tf
+++ b/locals.tf
@@ -17,6 +17,11 @@ locals {
   config_vault_service          = file("${path.module}/files/vault.service")
   config_vault_service_override = file("${path.module}/files/vault.service.d-override.conf")
 
+  config_vault_agent_service       = file("${path.module}/files/vault-agent.service")
+  config_vault_agent_hcl           = file("${path.module}/files/vault-agent.hcl")
+  config_vault_agent_cert_template = file("${path.module}/files/vault-agent/server.crt.ctmpl")
+  config_vault_agent_key_template  = file("${path.module}/files/vault-agent/server.key.ctmpl")
+
   config_snapshot_json = templatefile("${path.module}/templates/snapshot.json.tftpl", {
     aws_s3_bucket = aws_s3_bucket.vault_snapshots.id
     aws_s3_region = data.aws_region.current.region

--- a/locals.tf
+++ b/locals.tf
@@ -17,10 +17,11 @@ locals {
   config_vault_service          = file("${path.module}/files/vault.service")
   config_vault_service_override = file("${path.module}/files/vault.service.d-override.conf")
 
-  config_vault_agent_service       = file("${path.module}/files/vault-agent.service")
-  config_vault_agent_hcl           = file("${path.module}/files/vault-agent.hcl")
-  config_vault_agent_cert_template = file("${path.module}/files/vault-agent/server.crt.ctmpl")
-  config_vault_agent_key_template  = file("${path.module}/files/vault-agent/server.key.ctmpl")
+  # Vault Agent (wired into cloud-init in a later PR)
+  config_vault_agent_service       = file("${path.module}/files/vault-agent.service")          # tflint-ignore: terraform_unused_declarations
+  config_vault_agent_hcl           = file("${path.module}/files/vault-agent.hcl")              # tflint-ignore: terraform_unused_declarations
+  config_vault_agent_cert_template = file("${path.module}/files/vault-agent/server.crt.ctmpl") # tflint-ignore: terraform_unused_declarations
+  config_vault_agent_key_template  = file("${path.module}/files/vault-agent/server.key.ctmpl") # tflint-ignore: terraform_unused_declarations
 
   config_snapshot_json = templatefile("${path.module}/templates/snapshot.json.tftpl", {
     aws_s3_bucket = aws_s3_bucket.vault_snapshots.id


### PR DESCRIPTION
This is the second PR in the multi-PR Vault Agent rollout. It adds the static configuration files that Vault Agent will need once it is wired into the cloud-init bootstrap script in PR 3.

Four new files are introduced: a systemd unit for Vault Agent that depends on the main Vault service, an agent HCL configuration with AWS IAM auto-auth and consul-template rendering blocks, and two consul-template files that use the pkiCert helper to issue TLS certificates from the Vault PKI engine. The VAULT_FQDN_PLACEHOLDER in the templates will be substituted at cloud-init time in a later PR.

All four files are loaded into locals.tf via file() calls, but none of them are passed into the cloud-init templatefile() call or referenced by any resource. This means terraform plan produces no changes against an existing deployment. The files are dormant until the next PR wires them in.