### PR TITLE
feat: Wire Vault Agent files into cloud-init scaffolding

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -77,6 +77,11 @@ resource "aws_launch_template" "vault" {
     config_vault_service          = local.config_vault_service
     config_vault_service_override = local.config_vault_service_override
     config_snapshot_json          = local.config_snapshot_json
+
+    config_vault_agent_service       = local.config_vault_agent_service
+    config_vault_agent_hcl           = local.config_vault_agent_hcl
+    config_vault_agent_cert_template = local.config_vault_agent_cert_template
+    config_vault_agent_key_template  = local.config_vault_agent_key_template
   }))
 
   block_device_mappings {

--- a/locals.tf
+++ b/locals.tf
@@ -17,11 +17,10 @@ locals {
   config_vault_service          = file("${path.module}/files/vault.service")
   config_vault_service_override = file("${path.module}/files/vault.service.d-override.conf")
 
-  # Vault Agent (wired into cloud-init in a later PR)
-  config_vault_agent_service       = file("${path.module}/files/vault-agent.service")          # tflint-ignore: terraform_unused_declarations
-  config_vault_agent_hcl           = file("${path.module}/files/vault-agent.hcl")              # tflint-ignore: terraform_unused_declarations
-  config_vault_agent_cert_template = file("${path.module}/files/vault-agent/server.crt.ctmpl") # tflint-ignore: terraform_unused_declarations
-  config_vault_agent_key_template  = file("${path.module}/files/vault-agent/server.key.ctmpl") # tflint-ignore: terraform_unused_declarations
+  config_vault_agent_service       = file("${path.module}/files/vault-agent.service")
+  config_vault_agent_hcl           = file("${path.module}/files/vault-agent.hcl")
+  config_vault_agent_cert_template = file("${path.module}/files/vault-agent/server.crt.ctmpl")
+  config_vault_agent_key_template  = file("${path.module}/files/vault-agent/server.key.ctmpl")
 
   config_snapshot_json = templatefile("${path.module}/templates/snapshot.json.tftpl", {
     aws_s3_bucket = aws_s3_bucket.vault_snapshots.id

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -36,6 +36,13 @@ vault_tls_ca_file="$${vault_tls_dir}/ca.crt"
 vault_tls_cert_file="$${vault_tls_dir}/server.crt"
 vault_tls_key_file="$${vault_tls_dir}/server.key"
 
+# Vault Agent Directories
+vault_agent_config_dir="/etc/vault-agent"
+vault_agent_runtime_dir="/opt/vault/agent"
+vault_agent_config_file="$${vault_agent_config_dir}/agent.hcl"
+vault_agent_cert_template_file="$${vault_agent_config_dir}/server.crt.ctmpl"
+vault_agent_key_template_file="$${vault_agent_config_dir}/server.key.ctmpl"
+
 # EBS Volume Paths
 ebs_raft_device_name="${ebs_raft_device_name}"
 ebs_raft_mount="$${vault_raft_dir}"
@@ -318,6 +325,14 @@ configure_vault_directories() {
   mkdir -p "$${vault_raft_dir}"
   chown vault:vault "$${vault_raft_dir}"
   chmod 700 "$${vault_raft_dir}"
+
+  mkdir -p "$${vault_agent_config_dir}"
+  chown root:vault "$${vault_agent_config_dir}"
+  chmod 750 "$${vault_agent_config_dir}"
+
+  mkdir -p "$${vault_agent_runtime_dir}"
+  chown vault:vault "$${vault_agent_runtime_dir}"
+  chmod 750 "$${vault_agent_runtime_dir}"
 }
 
 # ---------------------------------------------------------------------------
@@ -395,6 +410,44 @@ EOF
 ${config_vault_service_override}
 EOF
   chmod 0600 /etc/systemd/system/vault.service.d/override.conf
+}
+
+write_vault_agent_config() {
+  log_info "Writing Vault Agent configuration"
+
+  cat >"$${vault_agent_config_file}" <<'EOF'
+${config_vault_agent_hcl}
+EOF
+
+  chown vault:vault "$${vault_agent_config_file}"
+  chmod 0640 "$${vault_agent_config_file}"
+}
+
+write_vault_agent_templates() {
+  log_info "Writing Vault Agent consul-template files"
+
+  cat >"$${vault_agent_cert_template_file}" <<'EOF'
+${config_vault_agent_cert_template}
+EOF
+
+  cat >"$${vault_agent_key_template_file}" <<'EOF'
+${config_vault_agent_key_template}
+EOF
+
+  sed -i "s|VAULT_FQDN_PLACEHOLDER|$${vault_fqdn}|g" \
+    "$${vault_agent_cert_template_file}" \
+    "$${vault_agent_key_template_file}"
+
+  chown vault:vault "$${vault_agent_cert_template_file}" "$${vault_agent_key_template_file}"
+  chmod 0640 "$${vault_agent_cert_template_file}" "$${vault_agent_key_template_file}"
+}
+
+write_vault_agent_systemd_unit() {
+  log_info "Writing Vault Agent systemd unit"
+
+  cat >/etc/systemd/system/vault-agent.service <<'EOF'
+${config_vault_agent_service}
+EOF
 }
 
 # ---------------------------------------------------------------------------
@@ -915,6 +968,9 @@ main() {
   configure_vault_directories
   install_vault
   write_vault_systemd_unit
+  write_vault_agent_config
+  write_vault_agent_templates
+  write_vault_agent_systemd_unit
 
   write_secrets
   write_vault_config "$${private_ip}" "$${instance_id}" "$${availability_zone}"


### PR DESCRIPTION
This is the third PR in the multi-PR Vault Agent rollout, stacked on the static-files PR that introduced the agent configuration files and locals.

The four Vault Agent locals are now passed through ec2.tf into the cloud-init template as template variables. Three new functions in the cloud-init script write the agent HCL config, consul-template cert and key files (with VAULT_FQDN_PLACEHOLDER substituted to the real FQDN), and the vault-agent.service systemd unit to disk during instance boot. The functions run in main() immediately after the existing write_vault_systemd_unit call and before write_secrets.

The agent service is intentionally not enabled or started. The systemd unit file lands on disk and will be picked up by the existing daemon-reload in start_services, but without an enable or start call the agent remains dormant. This means the cluster's runtime behavior is completely unchanged after this PR — Vault starts and operates exactly as before. The only observable difference is that the agent files exist on disk, ready for the next PR to activate the service.

Because the cloud-init template content has changed, terraform plan will show a launch template version change. This is expected and does not affect running instances until an instance refresh or new instance launch occurs. You can SSH into a node after deploy and confirm the files exist at /etc/vault-agent/ and /opt/vault/agent/, and manually run systemctl start vault-agent to validate the agent works end-to-end.