### PR TITLE
feat: Make Vault Agent the primary cert path when enabled

### DIFF
--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -517,6 +517,9 @@ start_services() {
 start_vault_agent() {
   log_info "Enabling the Vault Agent service"
 
+  touch /opt/vault/agent/.pre-start
+  chown vault:vault /opt/vault/agent/.pre-start
+
   systemctl daemon-reload
   systemctl enable --now vault-agent
 
@@ -551,6 +554,30 @@ wait_for_vault_api() {
     fi
 
     log_info "Vault API not yet available, retrying ($${attempts}/$${max_attempts})"
+    sleep 5
+  done
+}
+
+wait_for_pki_cert() {
+  log_info "Waiting for Vault Agent to render the first TLS certificate"
+
+  marker="/opt/vault/agent/.pre-start"
+  attempts=0
+  max_attempts=60
+
+  while true; do
+    if [ -f "$${vault_tls_cert_file}" ] && [ "$${vault_tls_cert_file}" -nt "$${marker}" ]; then
+      log_info "Vault Agent has rendered a new certificate at $${vault_tls_cert_file}"
+      return 0
+    fi
+
+    attempts=$((attempts + 1))
+    if [ "$${attempts}" -ge "$${max_attempts}" ]; then
+      log_error "Vault Agent did not render a certificate after $${max_attempts} attempts"
+      return 1
+    fi
+
+    log_info "Certificate not yet rendered by agent, retrying ($${attempts}/$${max_attempts})"
     sleep 5
   done
 }
@@ -947,6 +974,12 @@ cleanup_bootstrap_tls() {
     rm -f "$${pki_ca_tmp}"
     log_info "Removed temporary PKI CA cert file $${pki_ca_tmp}"
   fi
+
+  if [ "$${enable_vault_agent}" = "true" ]; then
+    log_info "Restarting Vault Agent to force re-read of rotated CA file"
+    systemctl restart vault-agent
+    log_info "Vault Agent restarted with updated CA file"
+  fi
 }
 
 write_vault_cli_config() {
@@ -997,20 +1030,28 @@ main() {
     configure_snapshots
     configure_pki_engine
     configure_aws_auth
-    issue_node_cert
+    if [ "$${enable_vault_agent}" = "true" ]; then
+      start_vault_agent
+      wait_for_pki_cert
+    else
+      issue_node_cert
+    fi
   else
     join_cluster
     wait_for_pki_ready
-    issue_node_cert
+    if [ "$${enable_vault_agent}" = "true" ]; then
+      start_vault_agent
+      wait_for_pki_cert
+    else
+      issue_node_cert
+    fi
   fi
 
-  replace_node_tls
+  if [ "$${enable_vault_agent}" != "true" ]; then
+    replace_node_tls
+  fi
   cleanup_bootstrap_tls
   write_vault_cli_config
-
-  if [ "$${enable_vault_agent}" = "true" ]; then
-    start_vault_agent
-  fi
 
   log_info "=== Bootstrap complete ==="
 }


### PR DESCRIPTION
This is the fifth PR in the multi-PR Vault Agent rollout, stacking on #65 (feature flag) which stacks on #64 (cloud-init scaffolding) and #63 (static files).

When enable_vault_agent is false (the default), behavior is unchanged from #65. The manual cert flow runs on every node: issue_node_cert issues the first PKI certificate, replace_node_tls HUPs Vault to present it, and cleanup_bootstrap_tls swaps the CA file on disk. Agent files exist on disk but the service is dormant.

When enable_vault_agent is true, the agent becomes responsible for the first TLS certificate as well as subsequent rotations. The bootstrap and follower paths in main() now branch on the flag after their respective setup steps (init_cluster/configure_aws_auth on the bootstrap node, join_cluster/wait_for_pki_ready on followers). On the agent path, start_vault_agent is called which touches a marker file at /opt/vault/agent/.pre-start, then enables and starts the agent service. A new wait_for_pki_cert function polls until the server cert file has an mtime newer than the marker, confirming that agent has successfully issued and rendered the certificate via its consul-template stanza. Because agent's template block includes a command that HUPs Vault, replace_node_tls is skipped on the agent path to avoid a redundant reload.

cleanup_bootstrap_tls still runs unconditionally on both paths since the bootstrap CA cert must always be replaced with the PKI CA cert. On the agent path, it now also restarts the agent after writing the new CA file, forcing a re-read rather than relying on agent to detect the change automatically.

The manual cert flow (issue_node_cert, replace_node_tls) is not deleted in this PR. It remains as the default-false code path and will be removed in a later PR once the agent path is validated in production. To test the agent path, set enable_vault_agent to true in the consuming deploy repo, do a fresh deploy, and verify that cloud-init logs show start_vault_agent and wait_for_pki_cert on all three nodes with no calls to issue_node_cert or replace_node_tls.