### PR TITLE
feat: Replace manual cert issuance with Vault Agent for PKI rotation

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -77,6 +77,10 @@ resource "aws_launch_template" "vault" {
     config_vault_service          = local.config_vault_service
     config_vault_service_override = local.config_vault_service_override
     config_snapshot_json          = local.config_snapshot_json
+    config_vault_agent_hcl        = local.config_vault_agent_hcl
+    config_vault_agent_service    = local.config_vault_agent_service
+    config_server_crt_ctmpl       = local.config_server_crt_ctmpl
+    config_server_key_ctmpl       = local.config_server_key_ctmpl
   }))
 
   block_device_mappings {

--- a/files/vault-agent.service
+++ b/files/vault-agent.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=HashiCorp Vault Agent
+Documentation=https://developer.hashicorp.com/vault/docs/agent-and-proxy/agent
+Requires=vault.service
+After=vault.service
+ConditionFileNotEmpty=/etc/vault-agent/agent.hcl
+
+[Service]
+Type=notify
+User=vault
+Group=vault
+ExecStart=/usr/bin/vault agent -config=/etc/vault-agent/agent.hcl
+KillMode=process
+KillSignal=SIGINT
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/locals.tf
+++ b/locals.tf
@@ -16,6 +16,17 @@ locals {
 
   config_vault_service          = file("${path.module}/files/vault.service")
   config_vault_service_override = file("${path.module}/files/vault.service.d-override.conf")
+  config_vault_agent_service    = file("${path.module}/files/vault-agent.service")
+
+  config_vault_agent_hcl = templatefile("${path.module}/templates/vault-agent.hcl.tftpl", {
+    vault_fqdn = local.vault_fqdn
+  })
+  config_server_crt_ctmpl = templatefile("${path.module}/templates/server.crt.ctmpl.tftpl", {
+    vault_fqdn = local.vault_fqdn
+  })
+  config_server_key_ctmpl = templatefile("${path.module}/templates/server.key.ctmpl.tftpl", {
+    vault_fqdn = local.vault_fqdn
+  })
 
   config_snapshot_json = templatefile("${path.module}/templates/snapshot.json.tftpl", {
     aws_s3_bucket = aws_s3_bucket.vault_snapshots.id

--- a/locals.tf
+++ b/locals.tf
@@ -22,10 +22,14 @@ locals {
     vault_fqdn = local.vault_fqdn
   })
   config_server_crt_ctmpl = templatefile("${path.module}/templates/server.crt.ctmpl.tftpl", {
-    vault_fqdn = local.vault_fqdn
+    vault_fqdn             = local.vault_fqdn
+    vault_pki_organization = var.vault_pki_organization
+    vault_pki_country      = var.vault_pki_country
   })
   config_server_key_ctmpl = templatefile("${path.module}/templates/server.key.ctmpl.tftpl", {
-    vault_fqdn = local.vault_fqdn
+    vault_fqdn             = local.vault_fqdn
+    vault_pki_organization = var.vault_pki_organization
+    vault_pki_country      = var.vault_pki_country
   })
 
   config_snapshot_json = templatefile("${path.module}/templates/snapshot.json.tftpl", {

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -756,7 +756,7 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# Vault Enterprise Self-issued Certificate Configuration
+# Vault Agent PKI Certificate Management
 # ---------------------------------------------------------------------------
 
 wait_for_pki_ready() {
@@ -788,71 +788,74 @@ wait_for_pki_ready() {
   done
 }
 
-issue_node_cert() {
-  log_info "Issuing PKI-signed TLS certificate for this node"
+setup_vault_agent() {
+  log_info "Setting up Vault Agent for PKI certificate management"
 
-  # Follower nodes need to fetch the new CA cert from SSM and authenticate
-  # via the AWS IAM auth method. The bootstrap node already has VAULT_TOKEN
-  # and VAULT_CACERT set from authenticate_vault().
-  if [ -z "$${VAULT_TOKEN:-}" ]; then
-    log_info "Fetching new PKI CA cert from SSM"
-    new_ca_cert="$(aws ssm get-parameter \
-      --region "$${region}" \
-      --name "$${ssm_pki_ca_cert_name}" \
-      --query "Parameter.Value" \
-      --output text)"
+  # Create agent runtime directory.
+  mkdir -p /opt/vault/agent
+  chown vault:vault /opt/vault/agent
+  chmod 0750 /opt/vault/agent
 
-    # Write the new PKI CA cert to disk for use by clients connecting
-    # to this node after the TLS swap in replace_node_tls(). It is not
-    # used for Vault API calls here, this node's listener is still
-    # presenting the bootstrap cert until the SIGHUP, so VAULT_CACERT
-    # must continue to point at the bootstrap CA.
-    new_ca_cert_file="$${vault_tls_dir}/pki-ca.crt"
-    printf '%s\n' "$${new_ca_cert}" >"$${new_ca_cert_file}"
-    chown vault:vault "$${new_ca_cert_file}"
-    chmod 0644 "$${new_ca_cert_file}"
+  # Create agent configuration directories.
+  mkdir -p /etc/vault-agent/templates
+  chown -R vault:vault /etc/vault-agent
+  chmod 0750 /etc/vault-agent /etc/vault-agent/templates
 
-    export VAULT_ADDR="https://127.0.0.1:8200"
-    export VAULT_CACERT="$${vault_tls_ca_file}"
+  # Write agent configuration.
+  cat >/etc/vault-agent/agent.hcl <<'AGENT_HCL'
+${config_vault_agent_hcl}
+AGENT_HCL
+  chown vault:vault /etc/vault-agent/agent.hcl
+  chmod 0640 /etc/vault-agent/agent.hcl
 
-    log_info "Authenticating via AWS IAM auth method"
-    vault_token="$(vault login \
-      -format=json \
-      -method=aws \
-      role=vault-server |
-      jq -r '.auth.client_token')"
-    export VAULT_TOKEN="$${vault_token}"
-  fi
+  # Write certificate templates (FQDN already baked in by Terraform).
+  cat >/etc/vault-agent/templates/server.crt.ctmpl <<'CTMPL_CERT'
+${config_server_crt_ctmpl}
+CTMPL_CERT
+  chown vault:vault /etc/vault-agent/templates/server.crt.ctmpl
+  chmod 0640 /etc/vault-agent/templates/server.crt.ctmpl
 
-  log_info "Requesting certificate from PKI engine"
-  cert_json="$(vault write -format=json pki/issue/vault-server \
-    common_name="$${vault_fqdn}" \
-    ttl=720h)"
+  cat >/etc/vault-agent/templates/server.key.ctmpl <<'CTMPL_KEY'
+${config_server_key_ctmpl}
+CTMPL_KEY
+  chown vault:vault /etc/vault-agent/templates/server.key.ctmpl
+  chmod 0640 /etc/vault-agent/templates/server.key.ctmpl
 
-  tmp_cert="$${vault_tls_dir}/server.crt.tmp"
-  tmp_key="$${vault_tls_dir}/server.key.tmp"
+  # Write systemd unit.
+  cat >/etc/systemd/system/vault-agent.service <<'AGENT_UNIT'
+${config_vault_agent_service}
+AGENT_UNIT
 
-  printf '%s\n' "$(printf '%s' "$${cert_json}" | jq -r '.data.certificate')" \
-    >"$${tmp_cert}"
-  printf '%s\n' "$(printf '%s' "$${cert_json}" | jq -r '.data.private_key')" \
-    >"$${tmp_key}"
+  # Remove bootstrap cert and key so we can detect when agent writes new ones.
+  # Vault already loaded these into memory at startup; it continues serving the
+  # in-memory bootstrap cert until the agent writes new files and triggers SIGHUP.
+  rm -f "$${vault_tls_cert_file}" "$${vault_tls_key_file}"
 
-  chown vault:vault "$${tmp_cert}" "$${tmp_key}"
-  chmod 0640 "$${tmp_cert}" "$${tmp_key}"
+  # Start Vault Agent.
+  systemctl daemon-reload
+  systemctl enable --now vault-agent
 
-  # Atomic move to final paths (vault.hcl already references these).
-  mv "$${tmp_cert}" "$${vault_tls_cert_file}"
-  mv "$${tmp_key}" "$${vault_tls_key_file}"
+  # Wait for the agent to issue the initial PKI certificate.
+  log_info "Waiting for Vault Agent to issue initial PKI certificate"
 
-  log_info "PKI-signed certificate written to $${vault_tls_cert_file}"
-}
+  attempts=0
+  max_attempts=30
 
-replace_node_tls() {
-  log_info "Reloading Vault TLS listener with PKI-signed certificate"
+  while true; do
+    if [ -f "$${vault_tls_cert_file}" ] && [ -f "$${vault_tls_key_file}" ]; then
+      log_info "Vault Agent has written PKI certificate to $${vault_tls_cert_file}"
+      return 0
+    fi
 
-  systemctl kill -s HUP vault
+    attempts=$((attempts + 1))
+    if [ "$${attempts}" -ge "$${max_attempts}" ]; then
+      log_error "Vault Agent did not issue certificate after $${max_attempts} attempts"
+      return 1
+    fi
 
-  log_info "Vault TLS listener reloaded"
+    log_info "Certificate not yet written, retrying ($${attempts}/$${max_attempts})"
+    sleep 5
+  done
 }
 
 cleanup_bootstrap_tls() {
@@ -929,14 +932,12 @@ main() {
     configure_snapshots
     configure_pki_engine
     configure_aws_auth
-    issue_node_cert
   else
     join_cluster
     wait_for_pki_ready
-    issue_node_cert
   fi
 
-  replace_node_tls
+  setup_vault_agent
   cleanup_bootstrap_tls
   write_vault_cli_config
 

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -821,6 +821,24 @@ CTMPL_KEY
   chown vault:vault /etc/vault-agent/templates/server.key.ctmpl
   chmod 0640 /etc/vault-agent/templates/server.key.ctmpl
 
+  # Write a reload helper that only sends SIGHUP once both the cert and key
+  # are on disk and belong to the same key pair. Vault Agent fires the command
+  # per-template, so without this guard the SIGHUP can arrive before the second
+  # file is written, causing a cert/key mismatch reload failure.
+  cat >/opt/vault/agent/reload-vault-tls.sh <<'RELOAD_SCRIPT'
+#!/bin/sh
+set -e
+cert_file="/opt/vault/tls/server.crt"
+key_file="/opt/vault/tls/server.key"
+[ -f "$cert_file" ] && [ -f "$key_file" ] || exit 0
+cert_pub=$(openssl x509 -noout -pubkey -in "$cert_file" 2>/dev/null)
+key_pub=$(openssl pkey -pubout -in "$key_file" 2>/dev/null)
+[ "$cert_pub" = "$key_pub" ] || exit 0
+kill -HUP $(systemctl show --property MainPID --value vault.service)
+RELOAD_SCRIPT
+  chown vault:vault /opt/vault/agent/reload-vault-tls.sh
+  chmod 0750 /opt/vault/agent/reload-vault-tls.sh
+
   # Write systemd unit.
   cat >/etc/systemd/system/vault-agent.service <<'AGENT_UNIT'
 ${config_vault_agent_service}

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -830,10 +830,10 @@ CTMPL_KEY
 set -e
 cert_file="/opt/vault/tls/server.crt"
 key_file="/opt/vault/tls/server.key"
-[ -f "$cert_file" ] && [ -f "$key_file" ] || exit 0
-cert_pub=$(openssl x509 -noout -pubkey -in "$cert_file" 2>/dev/null)
-key_pub=$(openssl pkey -pubout -in "$key_file" 2>/dev/null)
-[ "$cert_pub" = "$key_pub" ] || exit 0
+[ -f "$${cert_file}" ] && [ -f "$${key_file}" ] || exit 0
+cert_pub=$(openssl x509 -noout -pubkey -in "$${cert_file}" 2>/dev/null)
+key_pub=$(openssl pkey -pubout -in "$${key_file}" 2>/dev/null)
+[ "$${cert_pub}" = "$${key_pub}" ] || exit 0
 kill -HUP $(systemctl show --property MainPID --value vault.service)
 RELOAD_SCRIPT
   chown vault:vault /opt/vault/agent/reload-vault-tls.sh

--- a/templates/server.crt.ctmpl.tftpl
+++ b/templates/server.crt.ctmpl.tftpl
@@ -1,0 +1,2 @@
+{{ with pkiCert "pki/issue/vault-server" "common_name=${vault_fqdn}" "ttl=168h" }}
+{{ .Cert }}{{ .CA }}{{ end }}

--- a/templates/server.crt.ctmpl.tftpl
+++ b/templates/server.crt.ctmpl.tftpl
@@ -1,2 +1,2 @@
-{{ with pkiCert "pki/issue/vault-server" "common_name=${vault_fqdn}" "ttl=168h" }}
+{{ with pkiCert "pki/issue/vault-server" "common_name=${vault_fqdn}" "organization=${vault_pki_organization}" "country=${vault_pki_country}" "ttl=168h" }}
 {{ .Cert }}{{ .CA }}{{ end }}

--- a/templates/server.key.ctmpl.tftpl
+++ b/templates/server.key.ctmpl.tftpl
@@ -1,0 +1,2 @@
+{{ with pkiCert "pki/issue/vault-server" "common_name=${vault_fqdn}" "ttl=168h" }}
+{{ .Key }}{{ end }}

--- a/templates/server.key.ctmpl.tftpl
+++ b/templates/server.key.ctmpl.tftpl
@@ -1,2 +1,2 @@
-{{ with pkiCert "pki/issue/vault-server" "common_name=${vault_fqdn}" "ttl=168h" }}
+{{ with pkiCert "pki/issue/vault-server" "common_name=${vault_fqdn}" "organization=${vault_pki_organization}" "country=${vault_pki_country}" "ttl=168h" }}
 {{ .Key }}{{ end }}

--- a/templates/vault-agent.hcl.tftpl
+++ b/templates/vault-agent.hcl.tftpl
@@ -1,0 +1,30 @@
+pid_file = "/opt/vault/agent/agent.pid"
+
+vault {
+  address         = "https://127.0.0.1:8200"
+  ca_cert         = "/opt/vault/tls/ca.crt"
+  tls_server_name = "${vault_fqdn}"
+}
+
+auto_auth {
+  method "aws" {
+    mount_path = "auth/aws"
+    config = {
+      type = "iam"
+      role = "vault-server"
+    }
+  }
+}
+
+template {
+  source      = "/etc/vault-agent/templates/server.crt.ctmpl"
+  destination = "/opt/vault/tls/server.crt"
+  perms       = "0640"
+  command     = "/bin/sh -c 'kill -HUP $(systemctl show --property MainPID --value vault.service)'"
+}
+
+template {
+  source      = "/etc/vault-agent/templates/server.key.ctmpl"
+  destination = "/opt/vault/tls/server.key"
+  perms       = "0640"
+}

--- a/templates/vault-agent.hcl.tftpl
+++ b/templates/vault-agent.hcl.tftpl
@@ -20,11 +20,12 @@ template {
   source      = "/etc/vault-agent/templates/server.crt.ctmpl"
   destination = "/opt/vault/tls/server.crt"
   perms       = "0640"
+  command     = "/opt/vault/agent/reload-vault-tls.sh"
 }
 
 template {
   source      = "/etc/vault-agent/templates/server.key.ctmpl"
   destination = "/opt/vault/tls/server.key"
   perms       = "0640"
-  command     = "/bin/sh -c 'kill -HUP $(systemctl show --property MainPID --value vault.service)'"
+  command     = "/opt/vault/agent/reload-vault-tls.sh"
 }

--- a/templates/vault-agent.hcl.tftpl
+++ b/templates/vault-agent.hcl.tftpl
@@ -20,11 +20,11 @@ template {
   source      = "/etc/vault-agent/templates/server.crt.ctmpl"
   destination = "/opt/vault/tls/server.crt"
   perms       = "0640"
-  command     = "/bin/sh -c 'kill -HUP $(systemctl show --property MainPID --value vault.service)'"
 }
 
 template {
   source      = "/etc/vault-agent/templates/server.key.ctmpl"
   destination = "/opt/vault/tls/server.key"
   perms       = "0640"
+  command     = "/bin/sh -c 'kill -HUP $(systemctl show --property MainPID --value vault.service)'"
 }


### PR DESCRIPTION
- Add Vault Agent config (`vault-agent.hcl.tftpl`) with AWS IAM auto-auth and `pkiCert` template stanzas for `server.crt` and `server.key`
- Add consul-template files (`server.crt.ctmpl.tftpl`, `server.key.ctmpl.tftpl`) that use `pkiCert` for automatic cert renewal at ~2/3 TTL
- Add `vault-agent.service` systemd unit (`Type=notify`, `Requires=vault.service`)
- Replace `issue_node_cert` and `replace_node_tls` shell functions with `setup_vault_agent` in cloud-init
- Agent handles both initial issuance and ongoing leaf cert rotation, sending `SIGHUP` to Vault on each renewal via direct `kill` (same-user PID lookup)
- Wire new config files through `locals.tf` and `ec2.tf` using the existing `templatefile()`/`file()` pattern