### PR TITLE
refactor: Replace while true loops with bounded for loops in cloud-init

### DIFF
--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -136,7 +136,6 @@ get_availability_zone() {
 
 fetch_secret() {
   secret_arn="$${1}"
-  log_info "Fetching secret from AWS Secrets Manager: $${secret_arn}"
 
   for attempt in 1 2 3 4 5; do
     if result=$(aws secretsmanager get-secret-value \
@@ -146,8 +145,6 @@ fetch_secret() {
       printf '%s' "$${result}"
       return 0
     fi
-
-    log_info "Secret not yet available, retrying in 5 seconds ($${attempt}/5)"
     sleep 5
   done
 

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -137,10 +137,7 @@ get_availability_zone() {
 fetch_secret() {
   secret_arn="$${1}"
 
-  attempts=0
-  max_attempts=5
-
-  while true; do
+  for attempt in 1 2 3 4 5; do
     if result=$(aws secretsmanager get-secret-value \
       --region "$${region}" \
       --secret-id "$${secret_arn}" \
@@ -148,13 +145,13 @@ fetch_secret() {
       printf '%s' "$${result}"
       return 0
     fi
-    attempts=$((attempts + 1))
-    if [ "$${attempts}" -ge "$${max_attempts}" ]; then
-      log_error "Failed to retrieve secret after $${max_attempts} attempts: $${secret_arn}"
-      return 1
-    fi
+
+    log_info "Secret not yet available, retrying ($${attempt}/5): $${secret_arn}"
     sleep 5
   done
+
+  log_error "Failed to retrieve secret after 5 attempts: $${secret_arn}"
+  return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -246,22 +243,19 @@ prepare_disk() {
     return 1
   fi
 
-  attempts=0
-  max_attempts=12
   device=""
 
-  while true; do
+  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
     device="$(resolve_ebs_nvme_device "$${device_attachment_name}")" && break
 
-    attempts=$((attempts + 1))
-    if [ "$${attempts}" -ge "$${max_attempts}" ]; then
-      log_error "No NVMe device found matching $${device_attachment_name} after $${max_attempts} attempts"
-      return 1
-    fi
-
-    log_info "Device not yet visible, retrying ($${attempts}/$${max_attempts})"
+    log_info "Device not yet visible, retrying ($${attempt}/12)"
     sleep 5
   done
+
+  if [ -z "$${device}" ]; then
+    log_error "No NVMe device found matching $${device_attachment_name} after 1 minute"
+    return 1
+  fi
 
   log_info "Matched $${device_attachment_name} -> $${device}"
 
@@ -475,10 +469,7 @@ start_services() {
 wait_for_vault_api() {
   log_info "Waiting for Vault API to become available"
 
-  attempts=0
-  max_attempts=60
-
-  while true; do
+  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
     # curl returns 0 for any completed HTTP exchange regardless of status code.
     # We capture the HTTP status and treat anything other than 000 (no connection)
     # as success (501 means uninitialized, 503 means sealed, 200/429 means
@@ -493,15 +484,12 @@ wait_for_vault_api() {
       return 0
     fi
 
-    attempts=$((attempts + 1))
-    if [ "$${attempts}" -ge "$${max_attempts}" ]; then
-      log_error "Vault API did not respond after $${max_attempts} attempts"
-      return 1
-    fi
-
-    log_info "Vault API not yet available, retrying ($${attempts}/$${max_attempts})"
-    sleep 5
+    log_info "Vault API not yet available, retrying ($${attempt}/30)"
+    sleep 10
   done
+
+  log_error "Vault API did not respond after 5 minutes"
+  return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -592,10 +580,7 @@ init_cluster() {
 join_cluster() {
   log_info "Waiting for cluster initialization to complete"
 
-  attempts=0
-  max_attempts=60
-
-  while true; do
+  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
     state="$(aws ssm get-parameter \
       --region "$${region}" \
       --name "$${ssm_cluster_state_name}" \
@@ -607,15 +592,12 @@ join_cluster() {
       return 0
     fi
 
-    attempts=$((attempts + 1))
-    if [ "$${attempts}" -ge "$${max_attempts}" ]; then
-      log_error "Cluster did not reach ready state after $${max_attempts} attempts"
-      return 1
-    fi
-
-    log_info "Cluster state is '$${state}', retrying ($${attempts}/$${max_attempts})"
-    sleep 5
+    log_info "Cluster state is '$${state}', retrying ($${attempt}/30)"
+    sleep 10
   done
+
+  log_error "Cluster did not reach ready state after 5 minutes"
+  return 1
 }
 
 # ---------------------------------------------------------------------------
@@ -777,10 +759,7 @@ EOF
 wait_for_pki_ready() {
   log_info "Waiting for PKI bootstrap to complete"
 
-  attempts=0
-  max_attempts=60
-
-  while true; do
+  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
     state="$(aws ssm get-parameter \
       --region "$${region}" \
       --name "$${ssm_pki_state_name}" \
@@ -792,15 +771,12 @@ wait_for_pki_ready() {
       return 0
     fi
 
-    attempts=$((attempts + 1))
-    if [ "$${attempts}" -ge "$${max_attempts}" ]; then
-      log_error "PKI bootstrap did not reach ready state after $${max_attempts} attempts"
-      return 1
-    fi
-
-    log_info "PKI state is '$${state}', retrying ($${attempts}/$${max_attempts})"
-    sleep 5
+    log_info "PKI state is '$${state}', retrying ($${attempt}/30)"
+    sleep 10
   done
+
+  log_error "PKI bootstrap did not reach ready state after 5 minutes"
+  return 1
 }
 
 issue_node_cert() {

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -136,6 +136,7 @@ get_availability_zone() {
 
 fetch_secret() {
   secret_arn="$${1}"
+  log_info "Fetching secret from AWS Secrets Manager: $${secret_arn}"
 
   for attempt in 1 2 3 4 5; do
     if result=$(aws secretsmanager get-secret-value \
@@ -146,11 +147,11 @@ fetch_secret() {
       return 0
     fi
 
-    log_info "Secret not yet available, retrying ($${attempt}/5): $${secret_arn}"
+    log_info "Secret not yet available, retrying in 5 seconds ($${attempt}/5)"
     sleep 5
   done
 
-  log_error "Failed to retrieve secret after 5 attempts: $${secret_arn}"
+  log_error "Failed to retrieve secret after $${{attempt} attempts, failing bootstrap"
   return 1
 }
 
@@ -161,17 +162,16 @@ fetch_secret() {
 wait_for_network() {
   log_info "Waiting for network to become available"
 
-  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+  for attempt in 1 2 3 4 5; do
     if ping -c 1 -W 1 8.8.8.8 >/dev/null 2>&1; then
-      log_info "Network is available"
       return 0
     fi
 
-    log_info "Network not yet available, retrying ($${attempt}/12)"
-    sleep 10
+    log_info "Network not yet available, retrying in 5 seconds ($${attempt}/5)"
+    sleep 5
   done
 
-  log_error "Network did not become available after 2 minutes"
+  log_error "Network was not available after $${{attempt} attempts, failing bootstrap"
   return 1
 }
 
@@ -245,15 +245,15 @@ prepare_disk() {
 
   device=""
 
-  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12; do
+  for attempt in 1 2 3 4 5; do
     device="$(resolve_ebs_nvme_device "$${device_attachment_name}")" && break
 
-    log_info "Device not yet visible, retrying ($${attempt}/12)"
+    log_info "NVMe device not yet available, retrying in 5 seconds ($${attempt}/5)"
     sleep 5
   done
 
   if [ -z "$${device}" ]; then
-    log_error "No NVMe device found matching $${device_attachment_name} after 1 minute"
+    log_error "NVMe device was not found after $${{attempt}} attempts, failing bootstrap"
     return 1
   fi
 
@@ -469,13 +469,7 @@ start_services() {
 wait_for_vault_api() {
   log_info "Waiting for Vault API to become available"
 
-  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
-    # curl returns 0 for any completed HTTP exchange regardless of status code.
-    # We capture the HTTP status and treat anything other than 000 (no connection)
-    # as success (501 means uninitialized, 503 means sealed, 200/429 means
-    # active/standby). All indicate the API is up and TLS is working.
-    # -k is intentional: the bootstrap cert is self-signed and we connect to
-    # 127.0.0.1 during bootstrap, so hostname validation is not meaningful here.
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
     status="$(curl -sk -o /dev/null -w '%%{http_code}' \
       "https://127.0.0.1:8200/v1/sys/health" 2>/dev/null)" || true
 
@@ -484,11 +478,11 @@ wait_for_vault_api() {
       return 0
     fi
 
-    log_info "Vault API not yet available, retrying ($${attempt}/30)"
-    sleep 10
+    log_info "Vault API not yet available, retrying in 5 seconds ($${attempt}/10)"
+    sleep 5
   done
 
-  log_error "Vault API did not respond after 5 minutes"
+  log_error "Vault API did not respond after $${{attempt} attempts, failing bootstrap"
   return 1
 }
 
@@ -580,7 +574,7 @@ init_cluster() {
 join_cluster() {
   log_info "Waiting for cluster initialization to complete"
 
-  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
     state="$(aws ssm get-parameter \
       --region "$${region}" \
       --name "$${ssm_cluster_state_name}" \
@@ -588,15 +582,14 @@ join_cluster() {
       --output text 2>/dev/null)" || true
 
     if [ "$${state}" = "ready" ]; then
-      log_info "Cluster state is $${state}, proceeding"
       return 0
     fi
 
-    log_info "Cluster state is '$${state}', retrying ($${attempt}/30)"
-    sleep 10
+    log_info "Cluster state is '$${state}', retrying in 5 seconds ($${attempt}/10)"
+    sleep 5
   done
 
-  log_error "Cluster did not reach ready state after 5 minutes"
+  log_error "Unable to join the Vault cluster after $${{attempt} attempts, failing bootstrap"
   return 1
 }
 
@@ -759,7 +752,7 @@ EOF
 wait_for_pki_ready() {
   log_info "Waiting for PKI bootstrap to complete"
 
-  for attempt in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
     state="$(aws ssm get-parameter \
       --region "$${region}" \
       --name "$${ssm_pki_state_name}" \
@@ -771,11 +764,11 @@ wait_for_pki_ready() {
       return 0
     fi
 
-    log_info "PKI state is '$${state}', retrying ($${attempt}/30)"
-    sleep 10
+    log_info "PKI state is '$${state}', retrying in 5 seconds ($${attempt}/10)"
+    sleep 5
   done
 
-  log_error "PKI bootstrap did not reach ready state after 5 minutes"
+  log_error "Vault PKI was not ready after $${{attempt} attempts, failing bootstrap"
   return 1
 }
 


### PR DESCRIPTION
Replace all `while true` retry loops in `cloud-init.sh.tftpl` with bounded `for` loops