### PR TITLE
feat: Issue intermediate CA for PKI

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,6 @@ module "vault" {
 | <a name="output_vault_kms_key_id"></a> [vault\_kms\_key\_id](#output\_vault\_kms\_key\_id) | KMS key ID used for Vault auto-unseal. |
 | <a name="output_vault_snapshots_bucket"></a> [vault\_snapshots\_bucket](#output\_vault\_snapshots\_bucket) | S3 bucket for Vault snapshots. |
 | <a name="output_vault_target_group_arn"></a> [vault\_target\_group\_arn](#output\_vault\_target\_group\_arn) | ARN of the Vault NLB target group. |
-| <a name="output_vault_tls_ca_bundle"></a> [vault\_tls\_ca\_bundle](#output\_vault\_tls\_ca\_bundle) | Vault PKI Managed TLS CA Bundle |
+| <a name="output_vault_tls_ca_bundle_ssm_name"></a> [vault\_tls\_ca\_bundle\_ssm\_name](#output\_vault\_tls\_ca\_bundle\_ssm\_name) | SSM Parameter for the Vault PKI managed TLS CA bundle. |
 | <a name="output_vault_url"></a> [vault\_url](#output\_vault\_url) | URL of the Vault cluster. |
 <!-- END_TF_DOCS -->

--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ module "vault" {
 | [aws_security_group.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vpc_endpoints](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_ssm_parameter.vault_cluster_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.vault_pki_root_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.vault_pki_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.vault_tls_ca_bundle](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_vpc_endpoint.ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ module "vault" {
 | [aws_security_group.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vpc_endpoints](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_ssm_parameter.vault_cluster_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
-| [aws_ssm_parameter.vault_pki_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
+| [aws_ssm_parameter.vault_pki_root_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_ssm_parameter.vault_pki_state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssm_parameter) | resource |
 | [aws_vpc_endpoint.ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |
 | [aws_vpc_endpoint.kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_endpoint) | resource |

--- a/README.md
+++ b/README.md
@@ -94,11 +94,11 @@ module "vault" {
   # tflint-ignore: terraform_module_pinned_source
   source = "git::https://github.com/craigsloggett/terraform-aws-vault-enterprise"
 
-  project_name      = var.project_name
-  route53_zone      = data.aws_route53_zone.selected
-  vault_license     = var.vault_license
-  ec2_key_pair_name = var.ec2_key_pair_name
-  ec2_ami           = data.aws_ami.selected
+  project_name             = var.project_name
+  route53_zone             = data.aws_route53_zone.selected
+  vault_enterprise_license = var.vault_enterprise_license
+  ec2_key_pair_name        = var.ec2_key_pair_name
+  ec2_ami                  = data.aws_ami.selected
 
   nlb_internal            = var.nlb_internal
   vault_api_allowed_cidrs = var.vault_api_allowed_cidrs
@@ -137,7 +137,7 @@ module "vault" {
 | <a name="input_vault_api_allowed_cidrs"></a> [vault\_api\_allowed\_cidrs](#input\_vault\_api\_allowed\_cidrs) | CIDR blocks allowed to reach the Vault API (port 8200) from outside the VPC. Only effective when nlb\_internal is false. | `list(string)` | `[]` | no |
 | <a name="input_vault_audit_disk"></a> [vault\_audit\_disk](#input\_vault\_audit\_disk) | EBS configuration for the Vault Audit Log storage volume (/dev/xvdg). | <pre>object({<br/>    volume_type = optional(string, "gp3")<br/>    volume_size = optional(number, 50)<br/>  })</pre> | <pre>{<br/>  "volume_size": 50,<br/>  "volume_type": "gp3"<br/>}</pre> | no |
 | <a name="input_vault_data_disk"></a> [vault\_data\_disk](#input\_vault\_data\_disk) | EBS configuration for the Vault Raft Data storage volume (/dev/xvdf). | <pre>object({<br/>    volume_type = optional(string, "gp3")<br/>    volume_size = optional(number, 50)<br/>    iops        = optional(number, 3000)<br/>    throughput  = optional(number, 125)<br/>  })</pre> | <pre>{<br/>  "iops": 3000,<br/>  "throughput": 125,<br/>  "volume_size": 50,<br/>  "volume_type": "gp3"<br/>}</pre> | no |
-| <a name="input_vault_license"></a> [vault\_license](#input\_vault\_license) | Vault Enterprise license string. | `string` | n/a | yes |
+| <a name="input_vault_enterprise_license"></a> [vault\_enterprise\_license](#input\_vault\_enterprise\_license) | Vault Enterprise license string. | `string` | n/a | yes |
 | <a name="input_vault_node_count"></a> [vault\_node\_count](#input\_vault\_node\_count) | Number of Vault nodes in the cluster. Must be 3 or 5 for Raft quorum. | `number` | `3` | no |
 | <a name="input_vault_pki_country"></a> [vault\_pki\_country](#input\_vault\_pki\_country) | Country code for the PKI root CA. | `string` | `"US"` | no |
 | <a name="input_vault_pki_organization"></a> [vault\_pki\_organization](#input\_vault\_pki\_organization) | Organization name for the PKI root CA. | `string` | `"HashiCorp"` | no |
@@ -179,17 +179,17 @@ module "vault" {
 | [aws_s3_bucket_public_access_block.vault_snapshots](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_server_side_encryption_configuration.vault_snapshots](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.vault_snapshots](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
-| [aws_secretsmanager_secret.vault_bootstrap_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.vault_bootstrap_root_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret.vault_bootstrap_server_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret.vault_bootstrap_server_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret.vault_license](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.vault_bootstrap_tls_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.vault_bootstrap_tls_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.vault_bootstrap_tls_private_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.vault_enterprise_license](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.vault_recovery_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret_policy.vault_bootstrap_server_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_policy) | resource |
-| [aws_secretsmanager_secret_version.vault_bootstrap_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
-| [aws_secretsmanager_secret_version.vault_bootstrap_server_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
-| [aws_secretsmanager_secret_version.vault_bootstrap_server_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
-| [aws_secretsmanager_secret_version.vault_license](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_policy.vault_bootstrap_tls_private_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_policy) | resource |
+| [aws_secretsmanager_secret_version.vault_bootstrap_tls_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.vault_bootstrap_tls_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.vault_bootstrap_tls_private_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.vault_enterprise_license](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_security_group.bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.vpc_endpoints](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
@@ -208,16 +208,16 @@ module "vault" {
 | [aws_vpc_security_group_ingress_rule.vault_cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.vault_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
 | [aws_vpc_security_group_ingress_rule.vpc_endpoints_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/vpc_security_group_ingress_rule) | resource |
-| [tls_cert_request.bootstrap_server](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request) | resource |
-| [tls_locally_signed_cert.bootstrap_server](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/locally_signed_cert) | resource |
-| [tls_private_key.bootstrap_ca](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [tls_private_key.bootstrap_server](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [tls_self_signed_cert.bootstrap_ca](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
+| [tls_cert_request.vault_bootstrap_tls_cert_request](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/cert_request) | resource |
+| [tls_locally_signed_cert.vault_bootstrap_tls_cert](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/locally_signed_cert) | resource |
+| [tls_private_key.vault_bootstrap_tls_ca_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [tls_private_key.vault_bootstrap_tls_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [tls_self_signed_cert.vault_bootstrap_tls_ca_cert](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.vault_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_bootstrap_root_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vault_bootstrap_server_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vault_bootstrap_tls_private_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_ec2_describe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_iam_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -236,7 +236,7 @@ module "vault" {
 | <a name="output_bastion_public_ip"></a> [bastion\_public\_ip](#output\_bastion\_public\_ip) | Public IP of the bastion host. |
 | <a name="output_ec2_ami_name"></a> [ec2\_ami\_name](#output\_ec2\_ami\_name) | Name of the AMI used for EC2 instances. |
 | <a name="output_vault_asg_name"></a> [vault\_asg\_name](#output\_vault\_asg\_name) | Name of the Vault Auto Scaling Group. |
-| <a name="output_vault_bootstrap_ca_cert"></a> [vault\_bootstrap\_ca\_cert](#output\_vault\_bootstrap\_ca\_cert) | Bootstrap TLS CA certificate for trusting the Vault TLS chain. |
+| <a name="output_vault_bootstrap_tls_ca_cert"></a> [vault\_bootstrap\_tls\_ca\_cert](#output\_vault\_bootstrap\_tls\_ca\_cert) | Bootstrap TLS CA certificate |
 | <a name="output_vault_kms_key_id"></a> [vault\_kms\_key\_id](#output\_vault\_kms\_key\_id) | KMS key ID used for Vault auto-unseal. |
 | <a name="output_vault_snapshots_bucket"></a> [vault\_snapshots\_bucket](#output\_vault\_snapshots\_bucket) | S3 bucket for Vault snapshots. |
 | <a name="output_vault_target_group_arn"></a> [vault\_target\_group\_arn](#output\_vault\_target\_group\_arn) | ARN of the Vault NLB target group. |

--- a/README.md
+++ b/README.md
@@ -236,9 +236,9 @@ module "vault" {
 | <a name="output_bastion_public_ip"></a> [bastion\_public\_ip](#output\_bastion\_public\_ip) | Public IP of the bastion host. |
 | <a name="output_ec2_ami_name"></a> [ec2\_ami\_name](#output\_ec2\_ami\_name) | Name of the AMI used for EC2 instances. |
 | <a name="output_vault_asg_name"></a> [vault\_asg\_name](#output\_vault\_asg\_name) | Name of the Vault Auto Scaling Group. |
-| <a name="output_vault_bootstrap_tls_ca_cert"></a> [vault\_bootstrap\_tls\_ca\_cert](#output\_vault\_bootstrap\_tls\_ca\_cert) | Bootstrap TLS CA certificate |
 | <a name="output_vault_kms_key_id"></a> [vault\_kms\_key\_id](#output\_vault\_kms\_key\_id) | KMS key ID used for Vault auto-unseal. |
 | <a name="output_vault_snapshots_bucket"></a> [vault\_snapshots\_bucket](#output\_vault\_snapshots\_bucket) | S3 bucket for Vault snapshots. |
 | <a name="output_vault_target_group_arn"></a> [vault\_target\_group\_arn](#output\_vault\_target\_group\_arn) | ARN of the Vault NLB target group. |
+| <a name="output_vault_tls_ca_bundle"></a> [vault\_tls\_ca\_bundle](#output\_vault\_tls\_ca\_bundle) | Vault PKI Managed TLS CA Bundle |
 | <a name="output_vault_url"></a> [vault\_url](#output\_vault\_url) | URL of the Vault cluster. |
 <!-- END_TF_DOCS -->

--- a/cluster_bootstrap.tf
+++ b/cluster_bootstrap.tf
@@ -2,13 +2,13 @@
 
 # CA
 
-resource "tls_private_key" "bootstrap_ca" {
+resource "tls_private_key" "vault_bootstrap_tls_ca_private_key" {
   algorithm   = "ECDSA"
   ecdsa_curve = "P384"
 }
 
-resource "tls_self_signed_cert" "bootstrap_ca" {
-  private_key_pem = tls_private_key.bootstrap_ca.private_key_pem
+resource "tls_self_signed_cert" "vault_bootstrap_tls_ca_cert" {
+  private_key_pem = tls_private_key.vault_bootstrap_tls_ca_private_key.private_key_pem
 
   subject {
     common_name  = "${var.project_name} CA"
@@ -26,13 +26,13 @@ resource "tls_self_signed_cert" "bootstrap_ca" {
 
 # Private Key
 
-resource "tls_private_key" "bootstrap_server" {
+resource "tls_private_key" "vault_bootstrap_tls_private_key" {
   algorithm   = "ECDSA"
   ecdsa_curve = "P384"
 }
 
-resource "tls_cert_request" "bootstrap_server" {
-  private_key_pem = tls_private_key.bootstrap_server.private_key_pem
+resource "tls_cert_request" "vault_bootstrap_tls_cert_request" {
+  private_key_pem = tls_private_key.vault_bootstrap_tls_private_key.private_key_pem
 
   subject {
     common_name  = local.vault_fqdn
@@ -47,10 +47,10 @@ resource "tls_cert_request" "bootstrap_server" {
   ip_addresses = ["127.0.0.1"]
 }
 
-resource "tls_locally_signed_cert" "bootstrap_server" {
-  cert_request_pem   = tls_cert_request.bootstrap_server.cert_request_pem
-  ca_private_key_pem = tls_private_key.bootstrap_ca.private_key_pem
-  ca_cert_pem        = tls_self_signed_cert.bootstrap_ca.cert_pem
+resource "tls_locally_signed_cert" "vault_bootstrap_tls_cert" {
+  cert_request_pem   = tls_cert_request.vault_bootstrap_tls_cert_request.cert_request_pem
+  ca_private_key_pem = tls_private_key.vault_bootstrap_tls_ca_private_key.private_key_pem
+  ca_cert_pem        = tls_self_signed_cert.vault_bootstrap_tls_ca_cert.cert_pem
 
   validity_period_hours = 24
 
@@ -63,48 +63,48 @@ resource "tls_locally_signed_cert" "bootstrap_server" {
 
 # Secrets Manager
 
-resource "aws_secretsmanager_secret" "vault_bootstrap_ca_cert" {
+resource "aws_secretsmanager_secret" "vault_bootstrap_tls_ca_cert" {
   name_prefix = "${var.project_name}-vault-bootstrap-tls-ca-cert-"
-  description = "Bootstrap TLS CA certificate for Vault"
+  description = "Bootstrap TLS CA certificate"
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault-bootstrap-tls-ca-cert" })
 }
 
-resource "aws_secretsmanager_secret_version" "vault_bootstrap_ca_cert" {
-  secret_id     = aws_secretsmanager_secret.vault_bootstrap_ca_cert.id
-  secret_string = tls_self_signed_cert.bootstrap_ca.cert_pem
+resource "aws_secretsmanager_secret_version" "vault_bootstrap_tls_ca_cert" {
+  secret_id     = aws_secretsmanager_secret.vault_bootstrap_tls_ca_cert.id
+  secret_string = tls_self_signed_cert.vault_bootstrap_tls_ca_cert.cert_pem
 }
 
-resource "aws_secretsmanager_secret" "vault_bootstrap_server_cert" {
-  name_prefix = "${var.project_name}-vault-bootstrap-tls-server-cert-"
-  description = "Bootstrap TLS server certificate for Vault"
+resource "aws_secretsmanager_secret" "vault_bootstrap_tls_cert" {
+  name_prefix = "${var.project_name}-vault-bootstrap-tls-cert-"
+  description = "Bootstrap TLS Certificate"
 
-  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-bootstrap-tls-server-cert" })
+  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-bootstrap-tls-cert" })
 }
 
-resource "aws_secretsmanager_secret_version" "vault_bootstrap_server_cert" {
-  secret_id     = aws_secretsmanager_secret.vault_bootstrap_server_cert.id
-  secret_string = tls_locally_signed_cert.bootstrap_server.cert_pem
+resource "aws_secretsmanager_secret_version" "vault_bootstrap_tls_cert" {
+  secret_id     = aws_secretsmanager_secret.vault_bootstrap_tls_cert.id
+  secret_string = tls_locally_signed_cert.vault_bootstrap_tls_cert.cert_pem
 }
 
-resource "aws_secretsmanager_secret" "vault_bootstrap_server_key" {
-  name_prefix = "${var.project_name}-vault-bootstrap-tls-server-key-"
-  description = "Bootstrap TLS server private key for Vault"
+resource "aws_secretsmanager_secret" "vault_bootstrap_tls_private_key" {
+  name_prefix = "${var.project_name}-vault-bootstrap-tls-private-key-"
+  description = "Bootstrap TLS Private Key"
 
-  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-bootstrap-tls-server-key" })
+  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-bootstrap-tls-private-key" })
 }
 
-resource "aws_secretsmanager_secret_version" "vault_bootstrap_server_key" {
-  secret_id     = aws_secretsmanager_secret.vault_bootstrap_server_key.id
-  secret_string = tls_private_key.bootstrap_server.private_key_pem
+resource "aws_secretsmanager_secret_version" "vault_bootstrap_tls_private_key" {
+  secret_id     = aws_secretsmanager_secret.vault_bootstrap_tls_private_key.id
+  secret_string = tls_private_key.vault_bootstrap_tls_private_key.private_key_pem
 }
 
-resource "aws_secretsmanager_secret_policy" "vault_bootstrap_server_key" {
-  secret_arn = aws_secretsmanager_secret.vault_bootstrap_server_key.arn
-  policy     = data.aws_iam_policy_document.vault_bootstrap_server_key.json
+resource "aws_secretsmanager_secret_policy" "vault_bootstrap_tls_private_key" {
+  secret_arn = aws_secretsmanager_secret.vault_bootstrap_tls_private_key.arn
+  policy     = data.aws_iam_policy_document.vault_bootstrap_tls_private_key.json
 }
 
-data "aws_iam_policy_document" "vault_bootstrap_server_key" {
+data "aws_iam_policy_document" "vault_bootstrap_tls_private_key" {
   statement {
     sid    = "AllowVaultInstanceRole"
     effect = "Allow"
@@ -115,7 +115,7 @@ data "aws_iam_policy_document" "vault_bootstrap_server_key" {
     }
 
     actions   = ["secretsmanager:GetSecretValue"]
-    resources = [aws_secretsmanager_secret.vault_bootstrap_server_key.arn]
+    resources = [aws_secretsmanager_secret.vault_bootstrap_tls_private_key.arn]
   }
 }
 
@@ -123,7 +123,7 @@ data "aws_iam_policy_document" "vault_bootstrap_server_key" {
 
 resource "aws_secretsmanager_secret" "vault_bootstrap_root_token" {
   name_prefix = "${var.project_name}-vault-bootstrap-root-token-"
-  description = "Bootstrap root token for Vault (revoked after initialization)"
+  description = "Bootstrap Root Token"
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault-bootstrap-root-token" })
 }
@@ -131,10 +131,10 @@ resource "aws_secretsmanager_secret" "vault_bootstrap_root_token" {
 # Initialization Coordination SSM Parameters
 
 resource "aws_ssm_parameter" "vault_cluster_state" {
-  name        = "/${var.project_name}/vault/cluster/state"
+  name        = "/${var.project_name}/vault/bootstrap/cluster/state"
   type        = "String"
   value       = "uninitialized"
-  description = "Vault cluster initialization state flag (uninitialized | ready)"
+  description = "Bootstrap Initialization State Flag (uninitialized | ready)"
 
   lifecycle {
     ignore_changes = [value]
@@ -144,10 +144,10 @@ resource "aws_ssm_parameter" "vault_cluster_state" {
 }
 
 resource "aws_ssm_parameter" "vault_pki_state" {
-  name        = "/${var.project_name}/vault/pki/state"
+  name        = "/${var.project_name}/vault/bootstrap/pki/state"
   type        = "String"
   value       = "uninitialized"
-  description = "Vault PKI bootstrap state flag (uninitialized | ready)"
+  description = "Bootstrap PKI State Flag (uninitialized | ready)"
 
   lifecycle {
     ignore_changes = [value]

--- a/ec2.tf
+++ b/ec2.tf
@@ -72,11 +72,11 @@ resource "aws_launch_template" "vault" {
     vault_minimum_quorum_size             = var.vault_node_count
 
     # PKI and TLS
-    cluster_name                    = title(var.project_name)
-    vault_pki_state_ssm_name        = aws_ssm_parameter.vault_pki_state.name
-    vault_pki_root_ca_cert_ssm_name = aws_ssm_parameter.vault_pki_root_ca_cert.name
-    vault_pki_organization          = var.vault_pki_organization
-    vault_pki_country               = var.vault_pki_country
+    cluster_name                 = title(var.project_name)
+    vault_pki_organization       = var.vault_pki_organization
+    vault_pki_country            = var.vault_pki_country
+    vault_pki_state_ssm_name     = aws_ssm_parameter.vault_pki_state.name
+    vault_tls_ca_bundle_ssm_name = aws_ssm_parameter.vault_tls_ca_bundle.name
 
     # AWS Auth
     vault_iam_role_arn = aws_iam_role.vault.arn

--- a/ec2.tf
+++ b/ec2.tf
@@ -57,10 +57,10 @@ resource "aws_launch_template" "vault" {
     config_vault_hcl              = local.config_vault_hcl
 
     # Bootstrap Artifacts
-    vault_license_secret_arn             = aws_secretsmanager_secret.vault_enterprise_license.arn
+    vault_enterprise_license_secret_arn  = aws_secretsmanager_secret.vault_enterprise_license.arn
     bootstrap_tls_ca_cert_secret_arn     = aws_secretsmanager_secret.vault_bootstrap_tls_ca_cert.arn
-    bootstrap_tls_server_cert_secret_arn = aws_secretsmanager_secret.vault_bootstrap_tls_cert.arn
-    bootstrap_tls_server_key_secret_arn  = aws_secretsmanager_secret.vault_bootstrap_tls_private_key.arn
+    bootstrap_tls_cert_secret_arn        = aws_secretsmanager_secret.vault_bootstrap_tls_cert.arn
+    bootstrap_tls_private_key_secret_arn = aws_secretsmanager_secret.vault_bootstrap_tls_private_key.arn
     config_vault_snapshot_json           = local.config_vault_snapshot_json
 
     # Cluster Coordination

--- a/ec2.tf
+++ b/ec2.tf
@@ -57,7 +57,7 @@ resource "aws_launch_template" "vault" {
     config_vault_hcl              = local.config_vault_hcl
 
     # Bootstrap Artifacts
-    vault_license_secret_arn             = aws_secretsmanager_secret.vault_license.arn
+    vault_license_secret_arn             = aws_secretsmanager_secret.vault_enterprise_license.arn
     bootstrap_tls_ca_cert_secret_arn     = aws_secretsmanager_secret.vault_bootstrap_tls_ca_cert.arn
     bootstrap_tls_server_cert_secret_arn = aws_secretsmanager_secret.vault_bootstrap_tls_cert.arn
     bootstrap_tls_server_key_secret_arn  = aws_secretsmanager_secret.vault_bootstrap_tls_private_key.arn

--- a/ec2.tf
+++ b/ec2.tf
@@ -58,9 +58,9 @@ resource "aws_launch_template" "vault" {
 
     # Bootstrap Artifacts
     vault_license_secret_arn             = aws_secretsmanager_secret.vault_license.arn
-    bootstrap_tls_ca_cert_secret_arn     = aws_secretsmanager_secret.vault_bootstrap_ca_cert.arn
-    bootstrap_tls_server_cert_secret_arn = aws_secretsmanager_secret.vault_bootstrap_server_cert.arn
-    bootstrap_tls_server_key_secret_arn  = aws_secretsmanager_secret.vault_bootstrap_server_key.arn
+    bootstrap_tls_ca_cert_secret_arn     = aws_secretsmanager_secret.vault_bootstrap_tls_ca_cert.arn
+    bootstrap_tls_server_cert_secret_arn = aws_secretsmanager_secret.vault_bootstrap_tls_cert.arn
+    bootstrap_tls_server_key_secret_arn  = aws_secretsmanager_secret.vault_bootstrap_tls_private_key.arn
     config_vault_snapshot_json           = local.config_vault_snapshot_json
 
     # Cluster Coordination

--- a/ec2.tf
+++ b/ec2.tf
@@ -64,19 +64,19 @@ resource "aws_launch_template" "vault" {
     config_vault_snapshot_json           = local.config_vault_snapshot_json
 
     # Cluster Coordination
-    cluster_tag_key                       = local.cluster_tag_key
-    cluster_tag_value                     = local.cluster_tag_value
-    ssm_cluster_state_name                = aws_ssm_parameter.vault_cluster_state.name
+    vault_cluster_tag_key                 = local.vault_cluster_tag_key
+    vault_cluster_tag_value               = local.vault_cluster_tag_value
+    vault_cluster_state_ssm_name          = aws_ssm_parameter.vault_cluster_state.name
     vault_bootstrap_root_token_secret_arn = aws_secretsmanager_secret.vault_bootstrap_root_token.arn
     vault_recovery_keys_secret_arn        = aws_secretsmanager_secret.vault_recovery_keys.arn
     vault_minimum_quorum_size             = var.vault_node_count
 
     # PKI and TLS
-    cluster_name           = title(var.project_name)
-    ssm_pki_state_name     = aws_ssm_parameter.vault_pki_state.name
-    ssm_pki_ca_cert_name   = aws_ssm_parameter.vault_pki_ca_cert.name
-    vault_pki_organization = var.vault_pki_organization
-    vault_pki_country      = var.vault_pki_country
+    cluster_name                    = title(var.project_name)
+    vault_pki_state_ssm_name        = aws_ssm_parameter.vault_pki_state.name
+    vault_pki_root_ca_cert_ssm_name = aws_ssm_parameter.vault_pki_root_ca_cert.name
+    vault_pki_organization          = var.vault_pki_organization
+    vault_pki_country               = var.vault_pki_country
 
     # AWS Auth
     vault_iam_role_arn = aws_iam_role.vault.arn
@@ -130,8 +130,8 @@ resource "aws_launch_template" "vault" {
     resource_type = "instance"
 
     tags = merge(var.common_tags, {
-      Name                    = "${var.project_name}-vault-enterprise"
-      (local.cluster_tag_key) = local.cluster_tag_value
+      Name                          = "${var.project_name}-vault-enterprise"
+      (local.vault_cluster_tag_key) = local.vault_cluster_tag_value
     })
   }
 
@@ -182,7 +182,7 @@ resource "aws_autoscaling_group" "vault" {
 
   dynamic "tag" {
     for_each = merge(var.common_tags, {
-      (local.cluster_tag_key) = local.cluster_tag_value
+      (local.vault_cluster_tag_key) = local.vault_cluster_tag_value
     })
 
     content {

--- a/examples/basic/defaults.auto.tfvars.example
+++ b/examples/basic/defaults.auto.tfvars.example
@@ -1,9 +1,9 @@
-project_name      = "vault"
-route53_zone_name = "example.com"
-vault_license     = "your-vault-enterprise-license-here"
-ec2_key_pair_name = "my-key-pair"
-ec2_ami_owner     = "123456789012"
-ec2_ami_name      = "hc-base-ubuntu-2404-amd64-*"
+project_name             = "vault"
+route53_zone_name        = "example.com"
+vault_enterprise_license = "your-vault-enterprise-license-here"
+ec2_key_pair_name        = "my-key-pair"
+ec2_ami_owner            = "123456789012"
+ec2_ami_name             = "hc-base-ubuntu-2404-amd64-*"
 
 nlb_internal            = false
 vault_api_allowed_cidrs = ["0.0.0.0/0"]

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -16,11 +16,11 @@ module "vault" {
   # tflint-ignore: terraform_module_pinned_source
   source = "git::https://github.com/craigsloggett/terraform-aws-vault-enterprise"
 
-  project_name      = var.project_name
-  route53_zone      = data.aws_route53_zone.selected
-  vault_license     = var.vault_license
-  ec2_key_pair_name = var.ec2_key_pair_name
-  ec2_ami           = data.aws_ami.selected
+  project_name             = var.project_name
+  route53_zone             = data.aws_route53_zone.selected
+  vault_enterprise_license = var.vault_enterprise_license
+  ec2_key_pair_name        = var.ec2_key_pair_name
+  ec2_ami                  = data.aws_ami.selected
 
   nlb_internal            = var.nlb_internal
   vault_api_allowed_cidrs = var.vault_api_allowed_cidrs

--- a/examples/basic/variables.tf
+++ b/examples/basic/variables.tf
@@ -8,7 +8,7 @@ variable "route53_zone_name" {
   description = "Name of the existing Route 53 hosted zone."
 }
 
-variable "vault_license" {
+variable "vault_enterprise_license" {
   type        = string
   description = "Vault Enterprise license string."
   sensitive   = true

--- a/examples/existing-vpc/defaults.auto.tfvars.example
+++ b/examples/existing-vpc/defaults.auto.tfvars.example
@@ -1,10 +1,10 @@
-project_name      = "vault"
-vpc_name          = "hashistack"
-route53_zone_name = "example.com"
-vault_license     = "your-vault-enterprise-license-here"
-ec2_key_pair_name = "my-key-pair"
-ec2_ami_owner     = "123456789012"
-ec2_ami_name      = "hc-base-ubuntu-2404-amd64-*"
+project_name             = "vault"
+vpc_name                 = "hashistack"
+route53_zone_name        = "example.com"
+vault_enterprise_license = "your-vault-enterprise-license-here"
+ec2_key_pair_name        = "my-key-pair"
+ec2_ami_owner            = "123456789012"
+ec2_ami_name             = "hc-base-ubuntu-2404-amd64-*"
 
 nlb_internal            = false
 vault_api_allowed_cidrs = ["0.0.0.0/0"]

--- a/examples/existing-vpc/main.tf
+++ b/examples/existing-vpc/main.tf
@@ -45,11 +45,11 @@ module "vault" {
   # tflint-ignore: terraform_module_pinned_source
   source = "git::https://github.com/craigsloggett/terraform-aws-vault-enterprise"
 
-  project_name      = var.project_name
-  route53_zone      = data.aws_route53_zone.selected
-  vault_license     = var.vault_license
-  ec2_key_pair_name = var.ec2_key_pair_name
-  ec2_ami           = data.aws_ami.selected
+  project_name             = var.project_name
+  route53_zone             = data.aws_route53_zone.selected
+  vault_enterprise_license = var.vault_enterprise_license
+  ec2_key_pair_name        = var.ec2_key_pair_name
+  ec2_ami                  = data.aws_ami.selected
 
   nlb_internal            = var.nlb_internal
   vault_api_allowed_cidrs = var.vault_api_allowed_cidrs

--- a/examples/existing-vpc/variables.tf
+++ b/examples/existing-vpc/variables.tf
@@ -13,7 +13,7 @@ variable "route53_zone_name" {
   description = "Name of the existing Route 53 hosted zone."
 }
 
-variable "vault_license" {
+variable "vault_enterprise_license" {
   type        = string
   description = "Vault Enterprise license string."
   sensitive   = true

--- a/iam.tf
+++ b/iam.tf
@@ -144,7 +144,7 @@ data "aws_iam_policy_document" "vault_ssm" {
     resources = [
       aws_ssm_parameter.vault_cluster_state.arn,
       aws_ssm_parameter.vault_pki_state.arn,
-      aws_ssm_parameter.vault_pki_root_ca_cert.arn,
+      aws_ssm_parameter.vault_tls_ca_bundle.arn,
     ]
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -48,9 +48,9 @@ data "aws_iam_policy_document" "vault_secrets_manager" {
     actions = ["secretsmanager:GetSecretValue"]
     resources = [
       aws_secretsmanager_secret.vault_license.arn,
-      aws_secretsmanager_secret.vault_bootstrap_ca_cert.arn,
-      aws_secretsmanager_secret.vault_bootstrap_server_cert.arn,
-      aws_secretsmanager_secret.vault_bootstrap_server_key.arn,
+      aws_secretsmanager_secret.vault_bootstrap_tls_ca_cert.arn,
+      aws_secretsmanager_secret.vault_bootstrap_tls_cert.arn,
+      aws_secretsmanager_secret.vault_bootstrap_tls_private_key.arn,
     ]
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -47,7 +47,7 @@ data "aws_iam_policy_document" "vault_secrets_manager" {
     effect  = "Allow"
     actions = ["secretsmanager:GetSecretValue"]
     resources = [
-      aws_secretsmanager_secret.vault_license.arn,
+      aws_secretsmanager_secret.vault_enterprise_license.arn,
       aws_secretsmanager_secret.vault_bootstrap_tls_ca_cert.arn,
       aws_secretsmanager_secret.vault_bootstrap_tls_cert.arn,
       aws_secretsmanager_secret.vault_bootstrap_tls_private_key.arn,

--- a/iam.tf
+++ b/iam.tf
@@ -144,7 +144,7 @@ data "aws_iam_policy_document" "vault_ssm" {
     resources = [
       aws_ssm_parameter.vault_cluster_state.arn,
       aws_ssm_parameter.vault_pki_state.arn,
-      aws_ssm_parameter.vault_pki_ca_cert.arn,
+      aws_ssm_parameter.vault_pki_root_ca_cert.arn,
     ]
   }
 }

--- a/locals.tf
+++ b/locals.tf
@@ -10,10 +10,10 @@ locals {
   instance_refresh_min_healthy_pct = floor(
     (var.vault_node_count - 1) / var.vault_node_count * 100
   )
-  cluster_tag_key       = "vault-cluster"
-  cluster_tag_value     = var.project_name
-  ebs_raft_device_name  = "/dev/xvdf"
-  ebs_audit_device_name = "/dev/xvdg"
+  vault_cluster_tag_key   = "vault-cluster"
+  vault_cluster_tag_value = var.project_name
+  ebs_raft_device_name    = "/dev/xvdf"
+  ebs_audit_device_name   = "/dev/xvdg"
 
   # ---------------------------------------------------------------------------
   # Vault cluster configuration content
@@ -23,12 +23,12 @@ locals {
   config_vault_service_override = file("${path.module}/files/vault/vault.service.override.conf")
 
   config_vault_hcl = templatefile("${path.module}/templates/vault/vault.hcl.tftpl", {
-    cluster_name      = var.project_name
-    vault_fqdn        = trimsuffix(aws_route53_record.vault.fqdn, ".")
-    aws_region        = data.aws_region.current.region
-    kms_key_alias     = aws_kms_alias.vault.name
-    cluster_tag_key   = local.cluster_tag_key
-    cluster_tag_value = local.cluster_tag_value
+    cluster_name            = var.project_name
+    vault_fqdn              = trimsuffix(aws_route53_record.vault.fqdn, ".")
+    aws_region              = data.aws_region.current.region
+    kms_key_alias           = aws_kms_alias.vault.name
+    vault_cluster_tag_key   = local.vault_cluster_tag_key
+    vault_cluster_tag_value = local.vault_cluster_tag_value
   })
 
   config_vault_snapshot_json = templatefile("${path.module}/templates/vault/snapshot.json.tftpl", {

--- a/nlb.tf
+++ b/nlb.tf
@@ -38,7 +38,7 @@ resource "aws_lb_target_group" "vault" {
 
 resource "aws_lb_listener" "vault" {
   load_balancer_arn = aws_lb.vault.arn
-  port              = 8200
+  port              = 443
   protocol          = "TCP"
 
   default_action {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 output "vault_url" {
   description = "URL of the Vault cluster."
-  value       = "https://${local.vault_fqdn}:8200"
+  value       = "https://${local.vault_fqdn}"
 }
 
 output "bastion_public_ip" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,8 +33,7 @@ output "ec2_ami_name" {
   value       = var.ec2_ami.name
 }
 
-output "vault_bootstrap_ca_cert" {
-  description = "Bootstrap TLS CA certificate for trusting the Vault TLS chain."
-  value       = tls_self_signed_cert.bootstrap_ca.cert_pem
-  sensitive   = true
+output "vault_bootstrap_tls_ca_cert" {
+  description = "Bootstrap TLS CA certificate"
+  value       = tls_self_signed_cert.vault_bootstrap_tls_ca_cert.cert_pem
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,7 +33,8 @@ output "ec2_ami_name" {
   value       = var.ec2_ami.name
 }
 
-output "vault_bootstrap_tls_ca_cert" {
-  description = "Bootstrap TLS CA certificate"
-  value       = tls_self_signed_cert.vault_bootstrap_tls_ca_cert.cert_pem
+output "vault_tls_ca_bundle" {
+  description = "Vault PKI Managed TLS CA Bundle"
+  value       = aws_ssm_parameter.vault_tls_ca_bundle.value
+  sensitive   = false
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -33,7 +33,7 @@ output "ec2_ami_name" {
   value       = var.ec2_ami.name
 }
 
-output "vault_tls_ca_bundle" {
-  description = "Vault PKI Managed TLS CA Bundle"
-  value       = aws_ssm_parameter.vault_tls_ca_bundle.value
+output "vault_tls_ca_bundle_ssm_name" {
+  description = "SSM Parameter for the Vault PKI managed TLS CA bundle."
+  value       = aws_ssm_parameter.vault_tls_ca_bundle.name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -36,5 +36,4 @@ output "ec2_ami_name" {
 output "vault_tls_ca_bundle" {
   description = "Vault PKI Managed TLS CA Bundle"
   value       = aws_ssm_parameter.vault_tls_ca_bundle.value
-  sensitive   = false
 }

--- a/secretsmanager.tf
+++ b/secretsmanager.tf
@@ -1,18 +1,18 @@
-resource "aws_secretsmanager_secret" "vault_license" {
-  name_prefix = "${var.project_name}-vault-license-"
+resource "aws_secretsmanager_secret" "vault_enterprise_license" {
+  name_prefix = "${var.project_name}-vault-enterprise-license-"
   description = "Vault Enterprise license"
 
-  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-license" })
+  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-enterprise-license" })
 }
 
-resource "aws_secretsmanager_secret_version" "vault_license" {
-  secret_id     = aws_secretsmanager_secret.vault_license.id
-  secret_string = var.vault_license
+resource "aws_secretsmanager_secret_version" "vault_enterprise_license" {
+  secret_id     = aws_secretsmanager_secret.vault_enterprise_license.id
+  secret_string = var.vault_enterprise_license
 }
 
 resource "aws_secretsmanager_secret" "vault_recovery_keys" {
   name_prefix = "${var.project_name}-vault-recovery-keys-"
-  description = "Vault recovery keys"
+  description = "Vault Recovery Keys"
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault-recovery-keys" })
 }

--- a/secretsmanager.tf
+++ b/secretsmanager.tf
@@ -1,6 +1,6 @@
 resource "aws_secretsmanager_secret" "vault_enterprise_license" {
   name_prefix = "${var.project_name}-vault-enterprise-license-"
-  description = "Vault Enterprise license"
+  description = "Vault Enterprise License"
 
   tags = merge(var.common_tags, { Name = "${var.project_name}-vault-enterprise-license" })
 }

--- a/ssm.tf
+++ b/ssm.tf
@@ -1,5 +1,5 @@
-resource "aws_ssm_parameter" "vault_pki_root_ca_cert" {
-  name        = "/${var.project_name}/vault/pki-root/ca-cert"
+resource "aws_ssm_parameter" "vault_tls_ca_bundle" {
+  name        = "/${var.project_name}/vault/tls/ca-bundle"
   type        = "String"
   value       = "uninitialized"
   description = "Vault PKI root CA certificate PEM"

--- a/ssm.tf
+++ b/ssm.tf
@@ -1,7 +1,7 @@
 resource "aws_ssm_parameter" "vault_tls_ca_bundle" {
   name        = "/${var.project_name}/vault/tls/ca-bundle"
   type        = "String"
-  value       = ""
+  value       = "Uninitialized"
   description = "Vault PKI Managed TLS CA Bundle"
 
   lifecycle {

--- a/ssm.tf
+++ b/ssm.tf
@@ -1,12 +1,12 @@
 resource "aws_ssm_parameter" "vault_tls_ca_bundle" {
   name        = "/${var.project_name}/vault/tls/ca-bundle"
   type        = "String"
-  value       = "uninitialized"
-  description = "Vault PKI root CA certificate PEM"
+  value       = ""
+  description = "Vault PKI Managed TLS CA Bundle"
 
   lifecycle {
     ignore_changes = [value]
   }
 
-  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-pki-root-ca-cert" })
+  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-tls-ca-bundle" })
 }

--- a/ssm.tf
+++ b/ssm.tf
@@ -1,12 +1,12 @@
-resource "aws_ssm_parameter" "vault_pki_ca_cert" {
-  name        = "/${var.project_name}/vault/pki/ca-cert"
+resource "aws_ssm_parameter" "vault_pki_root_ca_cert" {
+  name        = "/${var.project_name}/vault/pki-root/ca-cert"
   type        = "String"
   value       = "uninitialized"
-  description = "Vault PKI CA certificate PEM (public)"
+  description = "Vault PKI root CA certificate PEM"
 
   lifecycle {
     ignore_changes = [value]
   }
 
-  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-pki-ca-cert" })
+  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-pki-root-ca-cert" })
 }

--- a/templates/agent/vault-server-tls.ctmpl.tftpl
+++ b/templates/agent/vault-server-tls.ctmpl.tftpl
@@ -3,3 +3,6 @@
 {{ .Cert }}
 {{ range .CAChain }}{{ . }}{{ end }}
 {{- end -}}
+{{- with secret "pki_root/cert/ca" -}}
+{{ .Data.certificate }}
+{{- end -}}

--- a/templates/agent/vault-server-tls.ctmpl.tftpl
+++ b/templates/agent/vault-server-tls.ctmpl.tftpl
@@ -1,4 +1,4 @@
-{{- with pkiCert "pki/issue/vault-server" "common_name=${vault_fqdn}" "ttl=24h" -}}
+{{- with pkiCert "pki_vault/issue/vault-server" "common_name=${vault_fqdn}" "ttl=24h" -}}
 {{ .Key | writeToFile "/opt/vault/tls/server.key.new" "vault" "vault" "0640" }}
 {{ .Cert }}
 {{ range .CAChain }}{{ . }}{{ end }}

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -47,10 +47,10 @@ readonly EBS_RAFT_DEVICE_NAME="${ebs_raft_device_name}"
 readonly EBS_AUDIT_DEVICE_NAME="${ebs_audit_device_name}"
 
 # Bootstrap Artifacts
-readonly VAULT_LICENSE_SECRET_ARN="${vault_license_secret_arn}"
+readonly VAULT_ENTERPRISE_LICENSE_SECRET_ARN="${vault_enterprise_license_secret_arn}"
 readonly BOOTSTRAP_TLS_CA_CERT_SECRET_ARN="${bootstrap_tls_ca_cert_secret_arn}"
-readonly BOOTSTRAP_TLS_SERVER_CERT_SECRET_ARN="${bootstrap_tls_server_cert_secret_arn}"
-readonly BOOTSTRAP_TLS_SERVER_KEY_SECRET_ARN="${bootstrap_tls_server_key_secret_arn}"
+readonly BOOTSTRAP_TLS_CERT_SECRET_ARN="${bootstrap_tls_cert_secret_arn}"
+readonly BOOTSTRAP_TLS_PRIVATE_KEY_SECRET_ARN="${bootstrap_tls_private_key_secret_arn}"
 
 # Cluster Coordination
 readonly VAULT_CLUSTER_TAG_KEY="${vault_cluster_tag_key}"
@@ -228,15 +228,15 @@ fetch_bootstrap_ca_cert() {
 }
 
 fetch_bootstrap_server_cert() {
-  fetch_secret "$${BOOTSTRAP_TLS_SERVER_CERT_SECRET_ARN}"
+  fetch_secret "$${BOOTSTRAP_TLS_CERT_SECRET_ARN}"
 }
 
 fetch_bootstrap_server_key() {
-  fetch_secret "$${BOOTSTRAP_TLS_SERVER_KEY_SECRET_ARN}"
+  fetch_secret "$${BOOTSTRAP_TLS_PRIVATE_KEY_SECRET_ARN}"
 }
 
 fetch_vault_license() {
-  fetch_secret "$${VAULT_LICENSE_SECRET_ARN}"
+  fetch_secret "$${VAULT_ENTERPRISE_LICENSE_SECRET_ARN}"
 }
 
 #######################################
@@ -647,8 +647,6 @@ configure_file_audit_device() {
   if ! vault audit list -format=json | jq -e '."file/"' >/dev/null 2>&1; then
     vault audit enable file file_path="$${VAULT_AUDIT_LOG_FILE}"
   fi
-
-  log_info "Vault file audit device configured"
 }
 
 configure_autopilot() {
@@ -658,8 +656,6 @@ configure_autopilot() {
     -cleanup-dead-servers=true \
     -dead-server-last-contact-threshold=10m \
     -min-quorum=$${VAULT_MINIMUM_QUORUM_SIZE}
-
-  log_info "Raft Autopilot configured"
 }
 
 configure_snapshots() {
@@ -668,8 +664,6 @@ configure_snapshots() {
   vault write sys/storage/raft/snapshot-auto/config/hourly \
     @"$${VAULT_SNAPSHOT_CONFIG_FILE}" \
     >/dev/null
-
-  log_info "Automated Raft snapshots configured"
 }
 
 write_vault_snapshot_config() {
@@ -694,9 +688,8 @@ configure_pki_root_secrets_engine() {
     vault secrets enable -path=pki_root pki
   fi
 
+  log_info "Configuring root PKI secrets engine max-lease-ttl"
   vault secrets tune -max-lease-ttl="$${VAULT_PKI_ROOT_MOUNT_MAX_TTL}" pki_root >/dev/null
-
-  log_info "Root PKI secrets engine enabled"
 }
 
 configure_pki_root_ca() {
@@ -718,8 +711,6 @@ configure_pki_root_ca() {
     key_type=ec \
     key_bits=384 \
     >/dev/null
-
-  log_info "PKI root CA configured"
 }
 
 configure_pki_vault_secrets_engine() {
@@ -739,6 +730,14 @@ configure_pki_vault_intermediate_ca() {
 
   tmp_dir="$(mktemp -d)"
   trap 'rm -rf "$${tmp_dir}"' EXIT
+
+  # Configure the pki_vault URLs first to embed the AIA
+  # fields into the root cert at generation time.
+  vault write pki_vault/config/urls \
+    issuing_certificates="https://$${VAULT_FQDN}:8200/v1/pki_vault/ca" \
+    crl_distribution_points="https://$${VAULT_FQDN}:8200/v1/pki_vault/crl" \
+    ocsp_servers="https://$${VAULT_FQDN}:8200/v1/pki_vault/ocsp" \
+    >/dev/null
 
   # Generate CSR from the intermediate mount
   vault write -format=json pki_vault/intermediate/generate/internal \
@@ -761,14 +760,7 @@ configure_pki_vault_intermediate_ca() {
     certificate=@"$${tmp_dir}/pki_vault_intermediate.crt"
 
   # Clean up CSR/cert from disk
-  rm /tmp/pki_vault_intermediate.csr /tmp/pki_vault_intermediate.crt
-
-  vault write pki_vault/config/urls \
-    issuing_certificates="https://$${VAULT_FQDN}:8200/v1/pki_vault/ca" \
-    crl_distribution_points="https://$${VAULT_FQDN}:8200/v1/pki_vault/crl" \
-    ocsp_servers="https://$${VAULT_FQDN}:8200/v1/pki_vault/ocsp"
-
-  log_info "Vault PKI intermediate CA configured"
+  rm "$${tmp_dir}/pki_vault_intermediate.csr" "$${tmp_dir}/pki_vault_intermediate.crt"
 }
 
 configure_vault_server_pki_role() {
@@ -1026,6 +1018,7 @@ main() {
   vault_node_role="$(get_vault_node_role)"
 
   if [ "$${vault_node_role}" = "bootstrap" ]; then
+    log_info "=== Bootstrap Node ==="
     initialize_vault_cluster
     VAULT_TOKEN="$(fetch_secret "$${VAULT_BOOTSTRAP_ROOT_TOKEN_SECRET_ARN}")"
     export VAULT_TOKEN

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -757,7 +757,8 @@ configure_pki_vault_intermediate_ca() {
 
   # Import the signed cert back into the intermediate mount
   vault write pki_vault/intermediate/set-signed \
-    certificate=@"$${tmp_dir}/pki_vault_intermediate.crt"
+    certificate=@"$${tmp_dir}/pki_vault_intermediate.crt" \
+    >/dev/null
 
   # Clean up CSR/cert from disk
   rm "$${tmp_dir}/pki_vault_intermediate.csr" "$${tmp_dir}/pki_vault_intermediate.crt"

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -62,8 +62,6 @@ readonly VAULT_MINIMUM_QUORUM_SIZE="${vault_minimum_quorum_size}"
 
 # PKI and TLS
 readonly CLUSTER_NAME="${cluster_name}"
-readonly VAULT_PKI_STATE_SSM_NAME="${vault_pki_state_ssm_name}"
-readonly VAULT_PKI_ROOT_CA_CERT_SSM_NAME="${vault_pki_root_ca_cert_ssm_name}"
 readonly VAULT_PKI_ORGANIZATION="${vault_pki_organization}"
 readonly VAULT_PKI_COUNTRY="${vault_pki_country}"
 readonly VAULT_PKI_ROOT_MOUNT_MAX_TTL="87600h"
@@ -72,6 +70,8 @@ readonly VAULT_PKI_VAULT_MOUNT_MAX_TTL="26280h"
 readonly VAULT_PKI_VAULT_CA_TTL="26280h"
 readonly VAULT_PKI_VAULT_SERVER_ROLE_MAX_TTL="24h"
 readonly VAULT_PKI_SERVER_CERT_TTL="24h"
+readonly VAULT_PKI_STATE_SSM_NAME="${vault_pki_state_ssm_name}"
+readonly VAULT_TLS_CA_BUNDLE_SSM_NAME="${vault_tls_ca_bundle_ssm_name}"
 
 # AWS Auth
 readonly VAULT_IAM_ROLE_ARN="${vault_iam_role_arn}"
@@ -286,13 +286,13 @@ join_cluster() {
   return 1
 }
 
-publish_root_ca_certificate() {
-  log_info "Publishing PKI root CA cert to SSM"
+publish_tls_ca_bundle() {
+  log_info "Publishing PKI managed TLS CA bundle to SSM"
 
-  root_ca_cert_pem="$(vault read -field=certificate pki_root/cert/ca)"
-  put_parameter "$${VAULT_PKI_ROOT_CA_CERT_SSM_NAME}" "$${root_ca_cert_pem}"
-
-  log_info "PKI root CA cert published to SSM"
+  root_ca_cert="$(vault read -field=certificate pki_root/cert/ca)"
+  vault_intermediate_ca_cert="$(vault read -field=certificate pki_vault/cert/ca)"
+  tls_ca_bundle="$(printf '%s\n%s\n' "$${root_ca_cert}" "$${vault_intermediate_ca_cert}")"
+  put_parameter "$${VAULT_TLS_CA_BUNDLE_SSM_NAME}" "$${tls_ca_bundle}"
 }
 
 mark_pki_ready() {
@@ -795,15 +795,13 @@ EOF
 }
 
 write_cluster_ca_certificate() {
-  cluster_ca_cert="$(fetch_pki_ca_cert)"
+  cluster_tls_ca_bundle="$(fetch_tls_ca_bundle)"
 
-  log_info "Replacing bootstrap CA cert with PKI root CA cert on disk"
+  log_info "Replacing bootstrap CA cert with PKI managed TLS CA bundle"
 
-  printf '%s\n' "$${cluster_ca_cert}" >"$${VAULT_TLS_CA_FILE}"
+  printf '%s\n' "$${cluster_tls_ca_bundle}" >"$${VAULT_TLS_CA_FILE}"
   chown vault:vault "$${VAULT_TLS_CA_FILE}"
   chmod 0644 "$${VAULT_TLS_CA_FILE}"
-
-  log_info "Bootstrap CA cert replaced with PKI root CA cert at $${VAULT_TLS_CA_FILE}"
 
   temporary_cluster_ca_file="$${VAULT_TLS_DIR}/pki-ca.crt"
   if [ -f "$${temporary_cluster_ca_file}" ]; then
@@ -818,7 +816,7 @@ issue_vault_server_certificate() {
   # Follower nodes need to fetch the new CA cert from SSM and authenticate
   # via the AWS IAM auth method.
   if [ -z "$${VAULT_TOKEN:-}" ]; then
-    new_ca_cert="$(fetch_pki_ca_cert)"
+    new_ca_cert="$(fetch_tls_ca_bundle)"
 
     # Keep the bootstrap CA at VAULT_CACERT until the listener reloads. This
     # temporary file is only for follower-node AWS auth and later cleanup.
@@ -885,8 +883,8 @@ wait_for_pki_ready() {
   return 1
 }
 
-fetch_pki_ca_cert() {
-  fetch_parameter "$${VAULT_PKI_ROOT_CA_CERT_SSM_NAME}"
+fetch_tls_ca_bundle() {
+  fetch_parameter "$${VAULT_TLS_CA_BUNDLE_SSM_NAME}"
 }
 
 #######################################
@@ -1042,7 +1040,7 @@ main() {
     configure_pki_vault_intermediate_ca
     configure_vault_server_pki_role
     write_vault_server_policy
-    publish_root_ca_certificate
+    publish_tls_ca_bundle
     enable_aws_auth_method
     bind_vault_server_iam_role
     configure_file_audit_device

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -752,6 +752,8 @@ configure_pki_vault_intermediate_ca() {
   vault write -format=json pki_root/root/sign-intermediate \
     csr=@"$${tmp_dir}/pki_vault_intermediate.csr" \
     common_name="$${CLUSTER_NAME} Vault Intermediate CA" \
+    organization="$${VAULT_PKI_ORGANIZATION}" \
+    country="$${VAULT_PKI_COUNTRY}" \
     ttl="$${VAULT_PKI_VAULT_CA_TTL}" |
     jq -r '.data.certificate' >"$${tmp_dir}/pki_vault_intermediate.crt"
 

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -742,8 +742,6 @@ configure_pki_vault_intermediate_ca() {
   # Generate CSR from the intermediate mount
   vault write -format=json pki_vault/intermediate/generate/internal \
     common_name="$${CLUSTER_NAME} Vault Intermediate CA" \
-    organization="$${VAULT_PKI_ORGANIZATION}" \
-    country="$${VAULT_PKI_COUNTRY}" \
     key_type=ec \
     key_bits=384 |
     jq -r '.data.csr' >"$${tmp_dir}/pki_vault_intermediate.csr"
@@ -848,9 +846,10 @@ issue_vault_server_certificate() {
   tmp_cert="$${VAULT_TLS_DIR}/server.crt.tmp"
   tmp_key="$${VAULT_TLS_DIR}/server.key.tmp"
 
-  printf '%s\n%s\n' \
+  printf '%s\n%s\n%s\n' \
     "$(printf '%s' "$${cert_json}" | jq -r '.data.certificate')" \
     "$(printf '%s' "$${cert_json}" | jq -r '.data.ca_chain[]')" \
+    "$(vault read -field=certificate pki_root/cert/ca)" \
     >"$${tmp_cert}"
   printf '%s\n' "$(printf '%s' "$${cert_json}" | jq -r '.data.private_key')" >"$${tmp_key}"
 

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -189,6 +189,20 @@ put_parameter() {
 #   Vault Cluster Discovery Helpers   #
 #######################################
 
+get_vault_node_role() {
+  cluster_state="$(fetch_parameter "$${SSM_CLUSTER_STATE_NAME}" 2>/dev/null)" || cluster_state=""
+
+  if [ "$${cluster_state}" = "ready" ]; then
+    printf 'follower'
+  else
+    if is_bootstrap_node; then
+      printf 'bootstrap'
+    else
+      printf 'follower'
+    fi
+  fi
+}
+
 is_bootstrap_node() {
   instance_id="$(get_instance_id)"
 
@@ -205,38 +219,6 @@ is_bootstrap_node() {
   lowest_id="$(printf '%s' "$${all_ids}" | tr '\t' '\n' | sort | head -1)"
 
   [ "$${instance_id}" = "$${lowest_id}" ]
-}
-
-get_vault_node_role() {
-  cluster_state="$(fetch_parameter "$${SSM_CLUSTER_STATE_NAME}" 2>/dev/null)" || cluster_state=""
-
-  if [ "$${cluster_state}" = "ready" ]; then
-    printf 'follower'
-  else
-    if is_bootstrap_node; then
-      printf 'bootstrap'
-    else
-      printf 'follower'
-    fi
-  fi
-}
-
-wait_for_pki_ready() {
-  for attempt in 1 2 3 4 5 6 7 8 9 10; do
-    state="$(fetch_parameter "$${SSM_PKI_STATE_NAME}")" || true
-
-    if [ "$${state}" = "ready" ]; then
-      return 0
-    fi
-    sleep 5
-  done
-
-  log_error "Vault PKI was not ready after $${attempt} attempts, failing bootstrap"
-  return 1
-}
-
-fetch_pki_ca_cert() {
-  fetch_parameter "$${SSM_PKI_CA_CERT_NAME}"
 }
 
 fetch_bootstrap_ca_cert() {
@@ -851,6 +833,24 @@ reload_vault_listener() {
   systemctl kill --signal=SIGHUP --kill-whom=main vault.service
 
   log_info "Vault TLS listener reloaded"
+}
+
+wait_for_pki_ready() {
+  for attempt in 1 2 3 4 5 6 7 8 9 10; do
+    state="$(fetch_parameter "$${SSM_PKI_STATE_NAME}")" || true
+
+    if [ "$${state}" = "ready" ]; then
+      return 0
+    fi
+    sleep 5
+  done
+
+  log_error "Vault PKI was not ready after $${attempt} attempts, failing bootstrap"
+  return 1
+}
+
+fetch_pki_ca_cert() {
+  fetch_parameter "$${SSM_PKI_CA_CERT_NAME}"
 }
 
 #######################################

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -848,7 +848,10 @@ issue_vault_server_certificate() {
   tmp_cert="$${VAULT_TLS_DIR}/server.crt.tmp"
   tmp_key="$${VAULT_TLS_DIR}/server.key.tmp"
 
-  printf '%s\n' "$(printf '%s' "$${cert_json}" | jq -r '.data.certificate')" >"$${tmp_cert}"
+  printf '%s\n%s\n' \
+    "$(printf '%s' "$${cert_json}" | jq -r '.data.certificate')" \
+    "$(printf '%s' "$${cert_json}" | jq -r '.data.ca_chain[]')" \
+    >"$${tmp_cert}"
   printf '%s\n' "$(printf '%s' "$${cert_json}" | jq -r '.data.private_key')" >"$${tmp_key}"
 
   chown vault:vault "$${tmp_cert}" "$${tmp_key}"

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -53,21 +53,23 @@ readonly BOOTSTRAP_TLS_SERVER_CERT_SECRET_ARN="${bootstrap_tls_server_cert_secre
 readonly BOOTSTRAP_TLS_SERVER_KEY_SECRET_ARN="${bootstrap_tls_server_key_secret_arn}"
 
 # Cluster Coordination
-readonly CLUSTER_TAG_KEY="${cluster_tag_key}"
-readonly CLUSTER_TAG_VALUE="${cluster_tag_value}"
-readonly SSM_CLUSTER_STATE_NAME="${ssm_cluster_state_name}"
+readonly VAULT_CLUSTER_TAG_KEY="${vault_cluster_tag_key}"
+readonly VAULT_CLUSTER_TAG_VALUE="${vault_cluster_tag_value}"
+readonly VAULT_CLUSTER_STATE_SSM_NAME="${vault_cluster_state_ssm_name}"
 readonly VAULT_BOOTSTRAP_ROOT_TOKEN_SECRET_ARN="${vault_bootstrap_root_token_secret_arn}"
 readonly VAULT_RECOVERY_KEYS_SECRET_ARN="${vault_recovery_keys_secret_arn}"
 readonly VAULT_MINIMUM_QUORUM_SIZE="${vault_minimum_quorum_size}"
 
 # PKI and TLS
 readonly CLUSTER_NAME="${cluster_name}"
-readonly SSM_PKI_STATE_NAME="${ssm_pki_state_name}"
-readonly SSM_PKI_CA_CERT_NAME="${ssm_pki_ca_cert_name}"
+readonly VAULT_PKI_STATE_SSM_NAME="${vault_pki_state_ssm_name}"
+readonly VAULT_PKI_ROOT_CA_CERT_SSM_NAME="${vault_pki_root_ca_cert_ssm_name}"
 readonly VAULT_PKI_ORGANIZATION="${vault_pki_organization}"
 readonly VAULT_PKI_COUNTRY="${vault_pki_country}"
-readonly VAULT_PKI_MOUNT_MAX_TTL="87600h"
+readonly VAULT_PKI_ROOT_MOUNT_MAX_TTL="87600h"
 readonly VAULT_PKI_ROOT_CA_TTL="87600h"
+readonly VAULT_PKI_VAULT_MOUNT_MAX_TTL="26280h"
+readonly VAULT_PKI_VAULT_CA_TTL="26280h"
 readonly VAULT_PKI_VAULT_SERVER_ROLE_MAX_TTL="24h"
 readonly VAULT_PKI_SERVER_CERT_TTL="24h"
 
@@ -190,7 +192,7 @@ put_parameter() {
 #######################################
 
 get_vault_node_role() {
-  cluster_state="$(fetch_parameter "$${SSM_CLUSTER_STATE_NAME}" 2>/dev/null)" || cluster_state=""
+  cluster_state="$(fetch_parameter "$${VAULT_CLUSTER_STATE_SSM_NAME}" 2>/dev/null)" || cluster_state=""
 
   if [ "$${cluster_state}" = "ready" ]; then
     printf 'follower'
@@ -210,7 +212,7 @@ is_bootstrap_node() {
   all_ids="$(
     aws ec2 describe-instances \
       --filters \
-      "Name=tag:$${CLUSTER_TAG_KEY},Values=$${CLUSTER_TAG_VALUE}" \
+      "Name=tag:$${VAULT_CLUSTER_TAG_KEY},Values=$${VAULT_CLUSTER_TAG_VALUE}" \
       "Name=instance-state-name,Values=running" \
       --query "Reservations[].Instances[].InstanceId" \
       --output text
@@ -264,14 +266,14 @@ initialize_vault_cluster() {
   put_secret "$${VAULT_RECOVERY_KEYS_SECRET_ARN}" "$${recovery_keys}"
 
   log_info "Writing cluster state: ready"
-  put_parameter "$${SSM_CLUSTER_STATE_NAME}" "ready"
+  put_parameter "$${VAULT_CLUSTER_STATE_SSM_NAME}" "ready"
 
   log_info "Cluster initialization complete"
 }
 
 join_cluster() {
   for attempt in 1 2 3 4 5 6 7 8 9 10; do
-    state="$(fetch_parameter "$${SSM_CLUSTER_STATE_NAME}")" || true
+    state="$(fetch_parameter "$${VAULT_CLUSTER_STATE_SSM_NAME}")" || true
 
     if [ "$${state}" = "ready" ]; then
       return 0
@@ -284,19 +286,19 @@ join_cluster() {
   return 1
 }
 
-publish_cluster_ca_certificate() {
-  log_info "Publishing PKI CA cert to SSM"
+publish_root_ca_certificate() {
+  log_info "Publishing PKI root CA cert to SSM"
 
-  ca_cert_pem="$(vault read -field=certificate pki/cert/ca)"
-  put_parameter "$${SSM_PKI_CA_CERT_NAME}" "$${ca_cert_pem}"
+  root_ca_cert_pem="$(vault read -field=certificate pki_root/cert/ca)"
+  put_parameter "$${VAULT_PKI_ROOT_CA_CERT_SSM_NAME}" "$${root_ca_cert_pem}"
 
-  log_info "PKI CA cert published to SSM"
+  log_info "PKI root CA cert published to SSM"
 }
 
 mark_pki_ready() {
   log_info "Writing PKI state: ready"
 
-  put_parameter "$${SSM_PKI_STATE_NAME}" "ready"
+  put_parameter "$${VAULT_PKI_STATE_SSM_NAME}" "ready"
 }
 
 #######################################
@@ -685,23 +687,23 @@ EOF
 #        Configure PKI Engine         #
 #######################################
 
-configure_pki_mount() {
-  log_info "Enabling Vault PKI secrets engine"
+configure_pki_root_secrets_engine() {
+  log_info "Enabling root PKI secrets engine"
 
-  if ! vault secrets list -format=json | jq -e '."pki/"' >/dev/null 2>&1; then
-    vault secrets enable pki
+  if ! vault secrets list -format=json | jq -e '."pki_root/"' >/dev/null 2>&1; then
+    vault secrets enable -path=pki_root pki
   fi
 
-  vault secrets tune -max-lease-ttl="$${VAULT_PKI_MOUNT_MAX_TTL}" pki >/dev/null
+  vault secrets tune -max-lease-ttl="$${VAULT_PKI_ROOT_MOUNT_MAX_TTL}" pki_root >/dev/null
 
-  log_info "Vault PKI secrets engine enabled"
+  log_info "Root PKI secrets engine enabled"
 }
 
 configure_pki_root_ca() {
-  log_info "Generating PKI root CA"
+  log_info "Configuring PKI root CA"
 
-  vault write pki/root/generate/internal \
-    common_name="$${CLUSTER_NAME} Vault Root CA" \
+  vault write pki_root/root/generate/internal \
+    common_name="$${CLUSTER_NAME} Root CA" \
     organization="$${VAULT_PKI_ORGANIZATION}" \
     country="$${VAULT_PKI_COUNTRY}" \
     ttl="$${VAULT_PKI_ROOT_CA_TTL}" \
@@ -709,25 +711,68 @@ configure_pki_root_ca() {
     key_bits=384 \
     >/dev/null
 
-  log_info "PKI root CA generated"
-}
-
-configure_pki_urls() {
-  log_info "Configuring PKI issuing URLs"
-
-  vault write pki/config/urls \
-    issuing_certificates="https://$${VAULT_FQDN}:8200/v1/pki/ca" \
-    crl_distribution_points="https://$${VAULT_FQDN}:8200/v1/pki/crl" \
-    ocsp_servers="https://$${VAULT_FQDN}:8200/v1/pki/ocsp" \
+  vault write pki_root/config/urls \
+    issuing_certificates="https://$${VAULT_FQDN}:8200/v1/pki_root/ca" \
+    crl_distribution_points="https://$${VAULT_FQDN}:8200/v1/pki_root/crl" \
+    ocsp_servers="https://$${VAULT_FQDN}:8200/v1/pki_root/ocsp" \
     >/dev/null
 
-  log_info "PKI issuing URLs configured"
+  log_info "PKI root CA configured"
+}
+
+configure_pki_vault_secrets_engine() {
+  log_info "Enabling Vault PKI secrets engine"
+
+  if ! vault secrets list -format=json | jq -e '."pki_vault/"' >/dev/null 2>&1; then
+    vault secrets enable -path=pki_vault pki
+  fi
+
+  vault secrets tune -max-lease-ttl="$${VAULT_PKI_VAULT_MOUNT_MAX_TTL}" pki_vault >/dev/null
+
+  log_info "Vault PKI secrets engine enabled"
+}
+
+configure_pki_vault_intermediate_ca() {
+  log_info "Configuring Vault PKI intermediate CA"
+
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "$${tmp_dir}"' EXIT
+
+  # Generate CSR from the intermediate mount
+  vault write -format=json pki_vault/intermediate/generate/internal \
+    common_name="$${CLUSTER_NAME} Vault Intermediate CA" \
+    organization="$${VAULT_PKI_ORGANIZATION}" \
+    country="$${VAULT_PKI_COUNTRY}" \
+    key_type=ec \
+    key_bits=384 |
+    jq -r '.data.csr' >"$${tmp_dir}/pki_vault_intermediate.csr"
+
+  # Sign the CSR with the root CA
+  vault write -format=json pki_root/root/sign-intermediate \
+    csr=@"$${tmp_dir}/pki_vault_intermediate.csr" \
+    common_name="$${CLUSTER_NAME} Vault Intermediate CA" \
+    ttl="$${VAULT_PKI_VAULT_CA_TTL}" |
+    jq -r '.data.certificate' >"$${tmp_dir}/pki_vault_intermediate.crt"
+
+  # Import the signed cert back into the intermediate mount
+  vault write pki_vault/intermediate/set-signed \
+    certificate=@"$${tmp_dir}/pki_vault_intermediate.crt"
+
+  # Clean up CSR/cert from disk
+  rm /tmp/pki_vault_intermediate.csr /tmp/pki_vault_intermediate.crt
+
+  vault write pki_vault/config/urls \
+    issuing_certificates="https://$${VAULT_FQDN}:8200/v1/pki_vault/ca" \
+    crl_distribution_points="https://$${VAULT_FQDN}:8200/v1/pki_vault/crl" \
+    ocsp_servers="https://$${VAULT_FQDN}:8200/v1/pki_vault/ocsp"
+
+  log_info "Vault PKI intermediate CA configured"
 }
 
 configure_vault_server_pki_role() {
   log_info "Creating vault-server PKI role"
 
-  vault write pki/roles/vault-server \
+  vault write pki_vault/roles/vault-server \
     allowed_domains="$${VAULT_FQDN}" \
     allow_bare_domains=true \
     allow_subdomains=false \
@@ -742,18 +787,11 @@ configure_vault_server_pki_role() {
   log_info "vault-server PKI role created"
 }
 
-configure_pki_engine() {
-  configure_pki_mount
-  configure_pki_root_ca
-  configure_pki_urls
-  configure_vault_server_pki_role
-}
-
 write_vault_server_policy() {
   log_info "Writing vault-server policy"
 
   vault policy write vault-server - <<EOF
-path "pki/issue/vault-server" {
+path "pki_vault/issue/vault-server" {
   capabilities = ["create", "update"]
 }
 EOF
@@ -764,13 +802,13 @@ EOF
 write_cluster_ca_certificate() {
   cluster_ca_cert="$(fetch_pki_ca_cert)"
 
-  log_info "Replacing bootstrap CA cert with PKI CA cert on disk"
+  log_info "Replacing bootstrap CA cert with PKI root CA cert on disk"
 
   printf '%s\n' "$${cluster_ca_cert}" >"$${VAULT_TLS_CA_FILE}"
   chown vault:vault "$${VAULT_TLS_CA_FILE}"
   chmod 0644 "$${VAULT_TLS_CA_FILE}"
 
-  log_info "Bootstrap CA cert replaced with PKI CA cert at $${VAULT_TLS_CA_FILE}"
+  log_info "Bootstrap CA cert replaced with PKI root CA cert at $${VAULT_TLS_CA_FILE}"
 
   temporary_cluster_ca_file="$${VAULT_TLS_DIR}/pki-ca.crt"
   if [ -f "$${temporary_cluster_ca_file}" ]; then
@@ -807,7 +845,7 @@ issue_vault_server_certificate() {
 
   log_info "Requesting certificate from PKI engine"
   cert_json="$(
-    vault write -format=json pki/issue/vault-server \
+    vault write -format=json pki_vault/issue/vault-server \
       common_name="$${VAULT_FQDN}" \
       ttl="$${VAULT_PKI_SERVER_CERT_TTL}"
   )"
@@ -837,7 +875,7 @@ reload_vault_listener() {
 
 wait_for_pki_ready() {
   for attempt in 1 2 3 4 5 6 7 8 9 10; do
-    state="$(fetch_parameter "$${SSM_PKI_STATE_NAME}")" || true
+    state="$(fetch_parameter "$${VAULT_PKI_STATE_SSM_NAME}")" || true
 
     if [ "$${state}" = "ready" ]; then
       return 0
@@ -850,7 +888,7 @@ wait_for_pki_ready() {
 }
 
 fetch_pki_ca_cert() {
-  fetch_parameter "$${SSM_PKI_CA_CERT_NAME}"
+  fetch_parameter "$${VAULT_PKI_ROOT_CA_CERT_SSM_NAME}"
 }
 
 #######################################
@@ -999,9 +1037,14 @@ main() {
 
   # Enable PKI and TLS
   if [ "$${vault_node_role}" = "bootstrap" ]; then
-    configure_pki_engine
+    configure_pki_root_secrets_engine
+    configure_pki_root_ca
+    configure_pki_root_signing_policy
+    configure_pki_vault_secrets_engine
+    configure_pki_vault_intermediate_ca
+    configure_vault_server_pki_role
     write_vault_server_policy
-    publish_cluster_ca_certificate
+    publish_root_ca_certificate
     enable_aws_auth_method
     bind_vault_server_iam_role
     configure_file_audit_device

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -227,11 +227,11 @@ fetch_bootstrap_ca_cert() {
   fetch_secret "$${BOOTSTRAP_TLS_CA_CERT_SECRET_ARN}"
 }
 
-fetch_bootstrap_server_cert() {
+fetch_bootstrap_tls_cert() {
   fetch_secret "$${BOOTSTRAP_TLS_CERT_SECRET_ARN}"
 }
 
-fetch_bootstrap_server_key() {
+fetch_bootstrap_tls_private_key() {
   fetch_secret "$${BOOTSTRAP_TLS_PRIVATE_KEY_SECRET_ARN}"
 }
 
@@ -622,15 +622,15 @@ EOF
 }
 
 write_bootstrap_tls_materials() {
-  ca_cert="$(fetch_bootstrap_ca_cert)"
-  server_cert="$(fetch_bootstrap_server_cert)"
-  server_key="$(fetch_bootstrap_server_key)"
+  bootstrap_ca_cert="$(fetch_bootstrap_ca_cert)"
+  bootstrap_tls_cert="$(fetch_bootstrap_tls_cert)"
+  bootstrap_tls_private_key="$(fetch_bootstrap_tls_private_key)"
 
   log_info "Writing bootstrap TLS materials"
 
-  printf '%s\n' "$${ca_cert}" >"$${VAULT_TLS_CA_FILE}"
-  printf '%s\n' "$${server_cert}" >"$${VAULT_TLS_CERT_FILE}"
-  printf '%s\n' "$${server_key}" >"$${VAULT_TLS_KEY_FILE}"
+  printf '%s\n' "$${bootstrap_ca_cert}" >"$${VAULT_TLS_CA_FILE}"
+  printf '%s\n' "$${bootstrap_tls_cert}" >"$${VAULT_TLS_CERT_FILE}"
+  printf '%s\n' "$${bootstrap_tls_private_key}" >"$${VAULT_TLS_KEY_FILE}"
 
   chown vault:vault "$${VAULT_TLS_CA_FILE}" "$${VAULT_TLS_CERT_FILE}" "$${VAULT_TLS_KEY_FILE}"
   chmod 0644 "$${VAULT_TLS_CA_FILE}"

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -702,6 +702,14 @@ configure_pki_root_secrets_engine() {
 configure_pki_root_ca() {
   log_info "Configuring PKI root CA"
 
+  # Configure the pki_root URLs first to embed the AIA
+  # fields into the root cert at generation time.
+  vault write pki_root/config/urls \
+    issuing_certificates="https://$${VAULT_FQDN}:8200/v1/pki_root/ca" \
+    crl_distribution_points="https://$${VAULT_FQDN}:8200/v1/pki_root/crl" \
+    ocsp_servers="https://$${VAULT_FQDN}:8200/v1/pki_root/ocsp" \
+    >/dev/null
+
   vault write pki_root/root/generate/internal \
     common_name="$${CLUSTER_NAME} Root CA" \
     organization="$${VAULT_PKI_ORGANIZATION}" \
@@ -709,12 +717,6 @@ configure_pki_root_ca() {
     ttl="$${VAULT_PKI_ROOT_CA_TTL}" \
     key_type=ec \
     key_bits=384 \
-    >/dev/null
-
-  vault write pki_root/config/urls \
-    issuing_certificates="https://$${VAULT_FQDN}:8200/v1/pki_root/ca" \
-    crl_distribution_points="https://$${VAULT_FQDN}:8200/v1/pki_root/crl" \
-    ocsp_servers="https://$${VAULT_FQDN}:8200/v1/pki_root/ocsp" \
     >/dev/null
 
   log_info "PKI root CA configured"
@@ -1039,7 +1041,6 @@ main() {
   if [ "$${vault_node_role}" = "bootstrap" ]; then
     configure_pki_root_secrets_engine
     configure_pki_root_ca
-    configure_pki_root_signing_policy
     configure_pki_vault_secrets_engine
     configure_pki_vault_intermediate_ca
     configure_vault_server_pki_role

--- a/templates/vault/vault.hcl.tftpl
+++ b/templates/vault/vault.hcl.tftpl
@@ -25,7 +25,7 @@ storage "raft" {
   autopilot_redundancy_zone = "$${availability_zone}"
 
   retry_join {
-    auto_join             = "provider=aws tag_key=${cluster_tag_key} tag_value=${cluster_tag_value}"
+    auto_join             = "provider=aws tag_key=${vault_cluster_tag_key} tag_value=${vault_cluster_tag_value}"
     auto_join_scheme      = "https"
     leader_tls_servername = "${vault_fqdn}"
     leader_ca_cert_file   = "/opt/vault/tls/ca.crt"

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "route53_zone" {
   description = "Route 53 hosted zone for the Vault DNS record."
 }
 
-variable "vault_license" {
+variable "vault_enterprise_license" {
   type        = string
   description = "Vault Enterprise license string."
   sensitive   = true


### PR DESCRIPTION
This pull request introduces an intermediate certificate for the Vault managed PKI materials of this cluster. This will enable the ability to have Vault manage multiple services' PKI materials using a single chain of trust while allowing each service to be configured independently.