### PR TITLE
chore(ci): Update dependabot to only bump Terraform versions in the examples directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,12 @@ version: 2
 
 updates:
   - package-ecosystem: terraform
-    directory: /
+    directories:
+      - examples/**/*
     schedule:
       interval: weekly
     commit-message:
-      prefix: chore(deps)
+      prefix: chore(docs)
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
Reusable modules should not be bumped arbitrarily, that should be done by the module producer when needed (using a feature of a provider that is only available in a specific version). This updates Dependabot configuration to only look in the examples directory where the Terraform code is simulating the consumer of the module (which should keep their providers up to date).