### PR TITLE
fix: Rename bootstrap TLS CA cert to CA for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,14 +275,14 @@ module "vault" {
 | [aws_s3_bucket_server_side_encryption_configuration.vault_snapshots](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_server_side_encryption_configuration) | resource |
 | [aws_s3_bucket_versioning.vault_snapshots](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_secretsmanager_secret.vault_bootstrap_root_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
-| [aws_secretsmanager_secret.vault_bootstrap_tls_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.vault_bootstrap_tls_ca](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.vault_bootstrap_tls_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.vault_bootstrap_tls_private_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.vault_enterprise_license](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.vault_pki_intermediate_ca_signed_csr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.vault_recovery_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_policy.vault_bootstrap_tls_private_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_policy) | resource |
-| [aws_secretsmanager_secret_version.vault_bootstrap_tls_ca_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
+| [aws_secretsmanager_secret_version.vault_bootstrap_tls_ca](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.vault_bootstrap_tls_cert](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.vault_bootstrap_tls_private_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.vault_enterprise_license](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
@@ -309,7 +309,7 @@ module "vault" {
 | [tls_locally_signed_cert.vault_bootstrap_tls_cert](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/locally_signed_cert) | resource |
 | [tls_private_key.vault_bootstrap_tls_ca_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 | [tls_private_key.vault_bootstrap_tls_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
-| [tls_self_signed_cert.vault_bootstrap_tls_ca_cert](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
+| [tls_self_signed_cert.vault_bootstrap_tls_ca](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.vault_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/cluster_bootstrap.tf
+++ b/cluster_bootstrap.tf
@@ -7,7 +7,7 @@ resource "tls_private_key" "vault_bootstrap_tls_ca_private_key" {
   ecdsa_curve = "P384"
 }
 
-resource "tls_self_signed_cert" "vault_bootstrap_tls_ca_cert" {
+resource "tls_self_signed_cert" "vault_bootstrap_tls_ca" {
   private_key_pem = tls_private_key.vault_bootstrap_tls_ca_private_key.private_key_pem
 
   subject {
@@ -50,7 +50,7 @@ resource "tls_cert_request" "vault_bootstrap_tls_cert_request" {
 resource "tls_locally_signed_cert" "vault_bootstrap_tls_cert" {
   cert_request_pem   = tls_cert_request.vault_bootstrap_tls_cert_request.cert_request_pem
   ca_private_key_pem = tls_private_key.vault_bootstrap_tls_ca_private_key.private_key_pem
-  ca_cert_pem        = tls_self_signed_cert.vault_bootstrap_tls_ca_cert.cert_pem
+  ca_cert_pem        = tls_self_signed_cert.vault_bootstrap_tls_ca.cert_pem
 
   validity_period_hours = 24
 
@@ -63,16 +63,16 @@ resource "tls_locally_signed_cert" "vault_bootstrap_tls_cert" {
 
 # Secrets Manager
 
-resource "aws_secretsmanager_secret" "vault_bootstrap_tls_ca_cert" {
-  name_prefix = "${var.project_name}-vault-bootstrap-tls-ca-cert-"
-  description = "Bootstrap TLS CA Certificate"
+resource "aws_secretsmanager_secret" "vault_bootstrap_tls_ca" {
+  name_prefix = "${var.project_name}-vault-bootstrap-tls-ca-"
+  description = "Vault Bootstrap TLS CA"
 
-  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-bootstrap-tls-ca-cert" })
+  tags = merge(var.common_tags, { Name = "${var.project_name}-vault-bootstrap-tls-ca" })
 }
 
-resource "aws_secretsmanager_secret_version" "vault_bootstrap_tls_ca_cert" {
-  secret_id     = aws_secretsmanager_secret.vault_bootstrap_tls_ca_cert.id
-  secret_string = tls_self_signed_cert.vault_bootstrap_tls_ca_cert.cert_pem
+resource "aws_secretsmanager_secret_version" "vault_bootstrap_tls_ca" {
+  secret_id     = aws_secretsmanager_secret.vault_bootstrap_tls_ca.id
+  secret_string = tls_self_signed_cert.vault_bootstrap_tls_ca.cert_pem
 }
 
 resource "aws_secretsmanager_secret" "vault_bootstrap_tls_cert" {

--- a/ec2.tf
+++ b/ec2.tf
@@ -60,7 +60,7 @@ resource "aws_launch_template" "vault" {
 
     # Bootstrap Artifacts
     vault_enterprise_license_secret_arn  = aws_secretsmanager_secret.vault_enterprise_license.arn
-    bootstrap_tls_ca_cert_secret_arn     = aws_secretsmanager_secret.vault_bootstrap_tls_ca_cert.arn
+    bootstrap_tls_ca_secret_arn          = aws_secretsmanager_secret.vault_bootstrap_tls_ca.arn
     bootstrap_tls_cert_secret_arn        = aws_secretsmanager_secret.vault_bootstrap_tls_cert.arn
     bootstrap_tls_private_key_secret_arn = aws_secretsmanager_secret.vault_bootstrap_tls_private_key.arn
     config_vault_snapshot_json           = local.config_vault_snapshot_json

--- a/iam.tf
+++ b/iam.tf
@@ -48,7 +48,7 @@ data "aws_iam_policy_document" "vault_secrets_manager" {
     actions = ["secretsmanager:GetSecretValue"]
     resources = [
       aws_secretsmanager_secret.vault_enterprise_license.arn,
-      aws_secretsmanager_secret.vault_bootstrap_tls_ca_cert.arn,
+      aws_secretsmanager_secret.vault_bootstrap_tls_ca.arn,
       aws_secretsmanager_secret.vault_bootstrap_tls_cert.arn,
       aws_secretsmanager_secret.vault_bootstrap_tls_private_key.arn,
     ]

--- a/templates/cloud-init.sh.tftpl
+++ b/templates/cloud-init.sh.tftpl
@@ -49,7 +49,7 @@ readonly EBS_AUDIT_DEVICE_NAME="${ebs_audit_device_name}"
 
 # Bootstrap Artifacts
 readonly VAULT_ENTERPRISE_LICENSE_SECRET_ARN="${vault_enterprise_license_secret_arn}"
-readonly BOOTSTRAP_TLS_CA_CERT_SECRET_ARN="${bootstrap_tls_ca_cert_secret_arn}"
+readonly BOOTSTRAP_TLS_CA_SECRET_ARN="${bootstrap_tls_ca_secret_arn}"
 readonly BOOTSTRAP_TLS_CERT_SECRET_ARN="${bootstrap_tls_cert_secret_arn}"
 readonly BOOTSTRAP_TLS_PRIVATE_KEY_SECRET_ARN="${bootstrap_tls_private_key_secret_arn}"
 
@@ -209,7 +209,7 @@ write_vault_bootstrap_tls_materials() {
         exit 1
       fi
       log_info "Writing bootstrap TLS CA file"
-      fetch_bootstrap_ca_cert >"$${VAULT_TLS_CA_FILE}"
+      fetch_bootstrap_ca >"$${VAULT_TLS_CA_FILE}"
       ;;
     Ready)
       if [ "$${pki_state}" = "Ready" ]; then
@@ -219,11 +219,11 @@ write_vault_bootstrap_tls_materials() {
         # with a PKI-signed one.
         {
           fetch_tls_ca_bundle
-          fetch_bootstrap_ca_cert
+          fetch_bootstrap_ca
         } >"$${VAULT_TLS_CA_FILE}"
       else
         log_info "Writing bootstrap TLS CA file"
-        fetch_bootstrap_ca_cert >"$${VAULT_TLS_CA_FILE}"
+        fetch_bootstrap_ca >"$${VAULT_TLS_CA_FILE}"
       fi
       ;;
     *)
@@ -273,8 +273,8 @@ is_bootstrap_node() {
   [ "$${instance_id}" = "$${lowest_id}" ]
 }
 
-fetch_bootstrap_ca_cert() {
-  fetch_secret "$${BOOTSTRAP_TLS_CA_CERT_SECRET_ARN}"
+fetch_bootstrap_ca() {
+  fetch_secret "$${BOOTSTRAP_TLS_CA_SECRET_ARN}"
 }
 
 fetch_bootstrap_tls_cert() {


### PR DESCRIPTION
- Rename `vault_bootstrap_tls_ca_cert` resource identifiers to `vault_bootstrap_tls_ca` across all files
- Update secret `name_prefix` from `-tls-ca-cert-` to `-tls-ca-` and `Name` tag accordingly
- Fix inconsistent description: "Bootstrap TLS CA Certificate" → "Vault Bootstrap TLS CA"
- Rename shell function `fetch_bootstrap_ca_cert` → `fetch_bootstrap_ca` and variable `BOOTSTRAP_TLS_CA_CERT_SECRET_ARN` → `BOOTSTRAP_TLS_CA_SECRET_ARN` in cloud-init template