### PR TITLE
fix: Adopt cross-module CamelCase naming for IAM resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,17 +257,15 @@ module "vault" {
 | Name | Type |
 | ---- | ---- |
 | [aws_autoscaling_group.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
-| [aws_iam_instance_profile.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
-| [aws_iam_role.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy.vault_bootstrap_root_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.vault_ec2_describe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.vault_iam_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.vault_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.vault_pki_intermediate_ca_signed_csr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.vault_recovery_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.vault_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.vault_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
-| [aws_iam_role_policy.vault_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_instance_profile.vault_server_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.vault_server_instance](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.vault_server_ec2_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.vault_server_iam_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.vault_server_kms_read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.vault_server_s3_read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.vault_server_secrets_manager_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.vault_server_secrets_manager_read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_iam_role_policy.vault_server_ssm_read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_instance.bastion](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
 | [aws_kms_alias.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_alias) | resource |
 | [aws_kms_key.vault](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
@@ -320,18 +318,16 @@ module "vault" {
 | [tls_self_signed_cert.vault_bootstrap_tls_ca](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
-| [aws_iam_policy_document.vault_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vault_bootstrap_root_token](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_bootstrap_tls_private_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vault_ec2_describe](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vault_iam_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vault_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vault_pki_intermediate_ca_signed_csr](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vault_recovery_keys](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vault_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vault_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vault_server_ec2_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vault_server_iam_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vault_server_instance_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vault_server_kms_read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vault_server_s3_read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vault_server_secrets_manager_read](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vault_server_secrets_manager_read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.vault_server_ssm_read_write](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.vault_snapshots](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.vault_ssm](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_vpc.existing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
 

--- a/cluster_bootstrap.tf
+++ b/cluster_bootstrap.tf
@@ -111,7 +111,7 @@ data "aws_iam_policy_document" "vault_bootstrap_tls_private_key" {
 
     principals {
       type        = "AWS"
-      identifiers = [aws_iam_role.vault.arn]
+      identifiers = [aws_iam_role.vault_server_instance.arn]
     }
 
     actions   = ["secretsmanager:GetSecretValue"]

--- a/ec2.tf
+++ b/ec2.tf
@@ -26,7 +26,7 @@ resource "aws_launch_template" "vault" {
   key_name      = var.ec2_key_pair_name
 
   iam_instance_profile {
-    name = aws_iam_instance_profile.vault.name
+    name = aws_iam_instance_profile.vault_server_instance.name
   }
 
   network_interfaces {
@@ -89,7 +89,7 @@ resource "aws_launch_template" "vault" {
     vault_pki_mount_path                               = var.vault_pki_mount_path
 
     # AWS Auth
-    vault_iam_role_arn          = aws_iam_role.vault.arn
+    vault_iam_role_arn          = aws_iam_role.vault_server_instance.arn
     vault_aws_auth_role_max_ttl = var.vault_aws_auth_role_max_ttl
     vault_aws_auth_role_ttl     = var.vault_aws_auth_role_ttl
 
@@ -215,7 +215,7 @@ resource "aws_autoscaling_group" "vault" {
   }
 
   depends_on = [
-    aws_iam_role_policy.vault_kms,
-    aws_iam_role_policy.vault_secrets_manager,
+    aws_iam_role_policy.vault_server_kms_read_write,
+    aws_iam_role_policy.vault_server_secrets_manager_read,
   ]
 }

--- a/iam.tf
+++ b/iam.tf
@@ -1,4 +1,43 @@
-data "aws_iam_policy_document" "vault_assume_role" {
+locals {
+  iam_project_name = replace(title(replace(var.project_name, "-", " ")), " ", "")
+}
+
+moved {
+  from = aws_iam_role.vault
+  to   = aws_iam_role.vault_server_instance
+}
+
+moved {
+  from = aws_iam_instance_profile.vault
+  to   = aws_iam_instance_profile.vault_server_instance
+}
+
+moved {
+  from = aws_iam_role_policy.vault_kms
+  to   = aws_iam_role_policy.vault_server_kms_read_write
+}
+
+moved {
+  from = aws_iam_role_policy.vault_s3
+  to   = aws_iam_role_policy.vault_server_s3_read_write
+}
+
+moved {
+  from = aws_iam_role_policy.vault_ec2_describe
+  to   = aws_iam_role_policy.vault_server_ec2_read
+}
+
+moved {
+  from = aws_iam_role_policy.vault_ssm
+  to   = aws_iam_role_policy.vault_server_ssm_read_write
+}
+
+moved {
+  from = aws_iam_role_policy.vault_iam_read
+  to   = aws_iam_role_policy.vault_server_iam_read
+}
+
+data "aws_iam_policy_document" "vault_server_instance_assume_role" {
   statement {
     effect  = "Allow"
     actions = ["sts:AssumeRole"]
@@ -10,21 +49,23 @@ data "aws_iam_policy_document" "vault_assume_role" {
   }
 }
 
-resource "aws_iam_role" "vault" {
-  name_prefix        = "${var.project_name}-vault-"
-  assume_role_policy = data.aws_iam_policy_document.vault_assume_role.json
+resource "aws_iam_role" "vault_server_instance" {
+  name               = "VaultServer${local.iam_project_name}InstanceRole"
+  assume_role_policy = data.aws_iam_policy_document.vault_server_instance_assume_role.json
 
-  tags = merge(var.common_tags, { Name = "${var.project_name}-vault" })
+  tags = merge(var.common_tags, { Name = "VaultServer${local.iam_project_name}InstanceRole" })
 }
 
-resource "aws_iam_instance_profile" "vault" {
-  name_prefix = "${var.project_name}-vault-"
-  role        = aws_iam_role.vault.name
+resource "aws_iam_instance_profile" "vault_server_instance" {
+  name = "VaultServer${local.iam_project_name}InstanceProfile"
+  role = aws_iam_role.vault_server_instance.name
 
-  tags = merge(var.common_tags, { Name = "${var.project_name}-vault" })
+  tags = merge(var.common_tags, { Name = "VaultServer${local.iam_project_name}InstanceProfile" })
 }
 
-data "aws_iam_policy_document" "vault_kms" {
+# KMS (auto-unseal)
+
+data "aws_iam_policy_document" "vault_server_kms_read_write" {
   statement {
     effect = "Allow"
     actions = [
@@ -36,13 +77,15 @@ data "aws_iam_policy_document" "vault_kms" {
   }
 }
 
-resource "aws_iam_role_policy" "vault_kms" {
-  name_prefix = "${var.project_name}-kms-"
-  role        = aws_iam_role.vault.id
-  policy      = data.aws_iam_policy_document.vault_kms.json
+resource "aws_iam_role_policy" "vault_server_kms_read_write" {
+  name   = "VaultServer${local.iam_project_name}KMSReadWritePolicy"
+  role   = aws_iam_role.vault_server_instance.id
+  policy = data.aws_iam_policy_document.vault_server_kms_read_write.json
 }
 
-data "aws_iam_policy_document" "vault_secrets_manager" {
+# Secrets Manager (license, TLS materials, signed intermediate CSR)
+
+data "aws_iam_policy_document" "vault_server_secrets_manager_read" {
   statement {
     effect  = "Allow"
     actions = ["secretsmanager:GetSecretValue"]
@@ -51,17 +94,48 @@ data "aws_iam_policy_document" "vault_secrets_manager" {
       aws_secretsmanager_secret.vault_bootstrap_tls_ca.arn,
       aws_secretsmanager_secret.vault_bootstrap_tls_cert.arn,
       aws_secretsmanager_secret.vault_bootstrap_tls_private_key.arn,
+      aws_secretsmanager_secret.vault_pki_intermediate_ca_signed_csr.arn,
+    ]
+  }
+
+  statement {
+    effect    = "Allow"
+    actions   = ["secretsmanager:DescribeSecret"]
+    resources = [aws_secretsmanager_secret.vault_pki_intermediate_ca_signed_csr.arn]
+  }
+}
+
+resource "aws_iam_role_policy" "vault_server_secrets_manager_read" {
+  name   = "VaultServer${local.iam_project_name}SecretsManagerReadPolicy"
+  role   = aws_iam_role.vault_server_instance.id
+  policy = data.aws_iam_policy_document.vault_server_secrets_manager_read.json
+}
+
+# Secrets Manager (bootstrap root token, recovery keys — read/write during initialization)
+
+data "aws_iam_policy_document" "vault_server_secrets_manager_read_write" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutSecretValue",
+    ]
+    resources = [
+      aws_secretsmanager_secret.vault_bootstrap_root_token.arn,
+      aws_secretsmanager_secret.vault_recovery_keys.arn,
     ]
   }
 }
 
-resource "aws_iam_role_policy" "vault_secrets_manager" {
-  name_prefix = "${var.project_name}-secrets-"
-  role        = aws_iam_role.vault.id
-  policy      = data.aws_iam_policy_document.vault_secrets_manager.json
+resource "aws_iam_role_policy" "vault_server_secrets_manager_read_write" {
+  name   = "VaultServer${local.iam_project_name}SecretsManagerReadWritePolicy"
+  role   = aws_iam_role.vault_server_instance.id
+  policy = data.aws_iam_policy_document.vault_server_secrets_manager_read_write.json
 }
 
-data "aws_iam_policy_document" "vault_s3" {
+# S3 (snapshots)
+
+data "aws_iam_policy_document" "vault_server_s3_read_write" {
   statement {
     effect = "Allow"
     actions = [
@@ -77,13 +151,15 @@ data "aws_iam_policy_document" "vault_s3" {
   }
 }
 
-resource "aws_iam_role_policy" "vault_s3" {
-  name_prefix = "${var.project_name}-s3-"
-  role        = aws_iam_role.vault.id
-  policy      = data.aws_iam_policy_document.vault_s3.json
+resource "aws_iam_role_policy" "vault_server_s3_read_write" {
+  name   = "VaultServer${local.iam_project_name}S3ReadWritePolicy"
+  role   = aws_iam_role.vault_server_instance.id
+  policy = data.aws_iam_policy_document.vault_server_s3_read_write.json
 }
 
-data "aws_iam_policy_document" "vault_ec2_describe" {
+# EC2 (auto-join)
+
+data "aws_iam_policy_document" "vault_server_ec2_read" {
   statement {
     effect    = "Allow"
     actions   = ["ec2:DescribeInstances"]
@@ -91,51 +167,16 @@ data "aws_iam_policy_document" "vault_ec2_describe" {
   }
 }
 
-resource "aws_iam_role_policy" "vault_ec2_describe" {
-  name_prefix = "${var.project_name}-ec2-"
-  role        = aws_iam_role.vault.id
-  policy      = data.aws_iam_policy_document.vault_ec2_describe.json
+resource "aws_iam_role_policy" "vault_server_ec2_read" {
+  name   = "VaultServer${local.iam_project_name}EC2ReadPolicy"
+  role   = aws_iam_role.vault_server_instance.id
+  policy = data.aws_iam_policy_document.vault_server_ec2_read.json
 }
 
-data "aws_iam_policy_document" "vault_bootstrap_root_token" {
+# SSM Parameter Store (cluster, PKI, TLS state)
+
+data "aws_iam_policy_document" "vault_server_ssm_read_write" {
   statement {
-    sid    = "BootstrapRootTokenReadWrite"
-    effect = "Allow"
-    actions = [
-      "secretsmanager:GetSecretValue",
-      "secretsmanager:PutSecretValue",
-    ]
-    resources = [aws_secretsmanager_secret.vault_bootstrap_root_token.arn]
-  }
-}
-
-resource "aws_iam_role_policy" "vault_bootstrap_root_token" {
-  name_prefix = "${var.project_name}-bootstrap-root-token-"
-  role        = aws_iam_role.vault.id
-  policy      = data.aws_iam_policy_document.vault_bootstrap_root_token.json
-}
-
-data "aws_iam_policy_document" "vault_recovery_keys" {
-  statement {
-    sid    = "RecoveryKeysReadWrite"
-    effect = "Allow"
-    actions = [
-      "secretsmanager:GetSecretValue",
-      "secretsmanager:PutSecretValue",
-    ]
-    resources = [aws_secretsmanager_secret.vault_recovery_keys.arn]
-  }
-}
-
-resource "aws_iam_role_policy" "vault_recovery_keys" {
-  name_prefix = "${var.project_name}-recovery-keys-"
-  role        = aws_iam_role.vault.id
-  policy      = data.aws_iam_policy_document.vault_recovery_keys.json
-}
-
-data "aws_iam_policy_document" "vault_ssm" {
-  statement {
-    sid    = "ClusterStateReadWrite"
     effect = "Allow"
     actions = [
       "ssm:GetParameter",
@@ -150,43 +191,24 @@ data "aws_iam_policy_document" "vault_ssm" {
   }
 }
 
-resource "aws_iam_role_policy" "vault_ssm" {
-  name_prefix = "${var.project_name}-ssm-"
-  role        = aws_iam_role.vault.id
-  policy      = data.aws_iam_policy_document.vault_ssm.json
+resource "aws_iam_role_policy" "vault_server_ssm_read_write" {
+  name   = "VaultServer${local.iam_project_name}SSMReadWritePolicy"
+  role   = aws_iam_role.vault_server_instance.id
+  policy = data.aws_iam_policy_document.vault_server_ssm_read_write.json
 }
 
-data "aws_iam_policy_document" "vault_pki_intermediate_ca_signed_csr" {
+# IAM (resolve own role ARN at runtime)
+
+data "aws_iam_policy_document" "vault_server_iam_read" {
   statement {
-    sid    = "IntermediateCARead"
-    effect = "Allow"
-    actions = [
-      "secretsmanager:GetSecretValue",
-      "secretsmanager:DescribeSecret",
-    ]
-    resources = [aws_secretsmanager_secret.vault_pki_intermediate_ca_signed_csr.arn]
+    effect    = "Allow"
+    actions   = ["iam:GetRole"]
+    resources = [aws_iam_role.vault_server_instance.arn]
   }
 }
 
-resource "aws_iam_role_policy" "vault_pki_intermediate_ca_signed_csr" {
-  name_prefix = "${var.project_name}-pki-intermediate-ca-signed-csr-"
-  role        = aws_iam_role.vault.id
-  policy      = data.aws_iam_policy_document.vault_pki_intermediate_ca_signed_csr.json
-}
-
-data "aws_iam_policy_document" "vault_iam_read" {
-  statement {
-    sid    = "ResolveIAMRoleARN"
-    effect = "Allow"
-    actions = [
-      "iam:GetRole",
-    ]
-    resources = [aws_iam_role.vault.arn]
-  }
-}
-
-resource "aws_iam_role_policy" "vault_iam_read" {
-  name_prefix = "${var.project_name}-iam-read-"
-  role        = aws_iam_role.vault.id
-  policy      = data.aws_iam_policy_document.vault_iam_read.json
+resource "aws_iam_role_policy" "vault_server_iam_read" {
+  name   = "VaultServer${local.iam_project_name}IAMReadPolicy"
+  role   = aws_iam_role.vault_server_instance.id
+  policy = data.aws_iam_policy_document.vault_server_iam_read.json
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,7 +45,7 @@ output "vault_tls_ca_bundle_ssm_parameter_name" {
 
 output "vault_iam_role_name" {
   description = "Name of the Vault server IAM role."
-  value       = aws_iam_role.vault.name
+  value       = aws_iam_role.vault_server_instance.name
 }
 
 output "vault_jwt_auth_path" {


### PR DESCRIPTION
- Rename IAM role, instance profile, and inline policies to the cross-module pattern `{Workload}{Deployment}{AWSService}[{Permission}]{ResourceType}` (e.g. `VaultServerLabSecretsManagerReadPolicy`)
- Add `iam_project_name` local in `iam.tf` for the title-cased deployment slot
- Switch from `name_prefix` to deterministic `name`
- Update `Name` tag on role and instance profile to mirror the new AWS name
- Consolidate the two SecretsManager Read policies and the two SecretsManager ReadWrite policies (11 IAM resources -> 9 to avoid `{AWSService}{Permission}` collisions)
- Add 7 `moved` blocks for the 1:1 label renames so plan output is clean
- Update references in `ec2.tf`, `cluster_bootstrap.tf`, and `outputs.tf` to the new resource labels