### PR TITLE
fix: Make AMI input optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,12 @@ data "aws_route53_zone" "selected" {
   name = var.route53_zone_name
 }
 
-data "aws_ami" "selected" {
-  most_recent = true
-  owners      = [var.ami_owner]
-
-  filter {
-    name   = "name"
-    values = [var.ami_name]
-  }
-}
-
 module "vault" {
   # tflint-ignore: terraform_module_pinned_source
   source = "git::https://github.com/craigsloggett/terraform-aws-vault-enterprise"
 
   vault_enterprise_license = var.vault_enterprise_license
   route53_zone             = data.aws_route53_zone.selected
-  ami                      = data.aws_ami.selected
 }
 ```
 
@@ -50,7 +39,7 @@ module "vault" {
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_ami"></a> [ami](#input\_ami) | AMI for EC2 instances. Must be Ubuntu or Debian-based. Accepts the result of an `aws_ami` data source directly. | <pre>object({<br/>    id   = string<br/>    name = string<br/>  })</pre> | n/a | yes |
+| <a name="input_ami"></a> [ami](#input\_ami) | AMI for EC2 instances. Must be Ubuntu or Debian-based. Accepts the result of an `aws_ami` data source directly. | <pre>object({<br/>    owners = optional(list(string), ["amazon"])<br/>    name   = optional(string, "ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260503")<br/>  })</pre> | `{}` | no |
 | <a name="input_bastion"></a> [bastion](#input\_bastion) | Bastion host configuration. `allowed_cidrs` defaults to `["0.0.0.0/0"]` for<br/>convenience; restrict to known ranges in any production deployment. | <pre>object({<br/>    name          = optional(string, "vault-enterprise-bastion-host")<br/>    instance_type = optional(string, "t3.micro")<br/>    allowed_cidrs = optional(list(string), ["0.0.0.0/0"])<br/><br/>    security_group = optional(object({<br/>      name_prefix = optional(string, "vault-enterprise-bastion-host-")<br/>      name        = optional(string, "vault-enterprise-bastion-host")<br/>    }), {})<br/>  })</pre> | `{}` | no |
 | <a name="input_bootstrap"></a> [bootstrap](#input\_bootstrap) | AWS resources used only during the Vault bootstrap ceremony. Secrets Manager<br/>secrets hold ephemeral bootstrap TLS material that Vault-issued certificates<br/>replace post-bootstrap; SSM parameters hold non-sensitive coordination state<br/>and the intermediate CA CSR exchanged out-of-band. | <pre>object({<br/>    secretsmanager_secret = optional(object({<br/>      tls_ca_name_prefix          = optional(string, "vault-enterprise-bootstrap-tls-ca-")<br/>      tls_cert_name_prefix        = optional(string, "vault-enterprise-bootstrap-tls-cert-")<br/>      tls_private_key_name_prefix = optional(string, "vault-enterprise-bootstrap-tls-private-key-")<br/>    }), {})<br/><br/>    ssm_parameter = optional(object({<br/>      cluster_state_name = optional(string, "/vault-enterprise/bootstrap/cluster/state")<br/>      pki_state_name     = optional(string, "/vault-enterprise/bootstrap/pki/state")<br/>    }), {})<br/>  })</pre> | `{}` | no |
 | <a name="input_hcp_terraform_jwt_auth"></a> [hcp\_terraform\_jwt\_auth](#input\_hcp\_terraform\_jwt\_auth) | Configuration for the HCP Terraform JWT auth method that provides<br/>dynamic, short-lived Vault credentials to HCP Terraform workspaces.<br/>When `organization_name` and `workspace_id` are set, a JWT auth method<br/>is mounted at `mount_path` in the root namespace and configured to<br/>verify tokens against `hostname` via OIDC discovery. A role named<br/>`role_name` is created against that mount with `bound_claims`<br/>restricting authentication to the declared organization and workspace. | <pre>object({<br/>    hostname              = optional(string, "app.terraform.io")<br/>    organization_name     = optional(string, "")<br/>    workspace_id          = optional(string, "")<br/>    oidc_discovery_ca_pem = optional(string, "")<br/>    mount_path            = optional(string, "app-terraform-io")<br/>    role_name             = optional(string, "hcp-terraform")<br/>  })</pre> | `{}` | no |
@@ -137,6 +126,7 @@ module "vault" {
 | [tls_private_key.bootstrap_tls_ca_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 | [tls_private_key.bootstrap_tls_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
 | [tls_self_signed_cert.bootstrap_tls_ca](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/self_signed_cert) | resource |
+| [aws_ami.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/ec2.tf
+++ b/ec2.tf
@@ -1,7 +1,7 @@
 # Bastion Host
 
 resource "aws_instance" "bastion" {
-  ami                         = var.ami.id
+  ami                         = data.aws_ami.selected.id
   instance_type               = var.bastion.instance_type
   key_name                    = var.key_pair.key_name
   subnet_id                   = local.vpc.public_subnet_ids[0]
@@ -23,7 +23,7 @@ resource "aws_instance" "bastion" {
 
 resource "aws_launch_template" "vault_enterprise" {
   name_prefix   = var.vault_cluster.launch_template.name_prefix
-  image_id      = var.ami.id
+  image_id      = data.aws_ami.selected.id
   instance_type = var.vault_cluster.instance_type
   key_name      = var.key_pair.key_name
 

--- a/examples/self-signed-tls/README.md
+++ b/examples/self-signed-tls/README.md
@@ -163,8 +163,6 @@ resource "aws_secretsmanager_secret_version" "vault_pki_signed_intermediate_ca" 
 
 | Name | Description | Type | Default | Required |
 | ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_ami_name"></a> [ami\_name](#input\_ami\_name) | AMI name filter for the EC2 AMI data source. | `string` | n/a | yes |
-| <a name="input_ami_owner"></a> [ami\_owner](#input\_ami\_owner) | AWS account ID that owns the AMI. | `string` | n/a | yes |
 | <a name="input_route53_zone_name"></a> [route53\_zone\_name](#input\_route53\_zone\_name) | Name of the Route 53 hosted zone for the Vault DNS record. | `string` | n/a | yes |
 | <a name="input_vault_enterprise_license"></a> [vault\_enterprise\_license](#input\_vault\_enterprise\_license) | Vault Enterprise license string. | `string` | n/a | yes |
 

--- a/examples/self-signed-tls/README.md
+++ b/examples/self-signed-tls/README.md
@@ -58,23 +58,12 @@ data "aws_route53_zone" "selected" {
   name = var.route53_zone_name
 }
 
-data "aws_ami" "selected" {
-  most_recent = true
-  owners      = [var.ami_owner]
-
-  filter {
-    name   = "name"
-    values = [var.ami_name]
-  }
-}
-
 module "vault" {
   # tflint-ignore: terraform_module_pinned_source
   source = "git::https://github.com/craigsloggett/terraform-aws-vault-enterprise"
 
   vault_enterprise_license = var.vault_enterprise_license
   route53_zone             = data.aws_route53_zone.selected
-  ami                      = data.aws_ami.selected
 }
 ```
 
@@ -188,7 +177,6 @@ resource "aws_secretsmanager_secret_version" "vault_pki_signed_intermediate_ca" 
 | [tls_locally_signed_cert.vault_pki_signed_intermediate_ca](https://registry.terraform.io/providers/hashicorp/tls/4.2.1/docs/resources/locally_signed_cert) | resource |
 | [tls_private_key.root_ca](https://registry.terraform.io/providers/hashicorp/tls/4.2.1/docs/resources/private_key) | resource |
 | [tls_self_signed_cert.root_ca](https://registry.terraform.io/providers/hashicorp/tls/4.2.1/docs/resources/self_signed_cert) | resource |
-| [aws_ami.selected](https://registry.terraform.io/providers/hashicorp/aws/6.43.0/docs/data-sources/ami) | data source |
 | [aws_region.this](https://registry.terraform.io/providers/hashicorp/aws/6.43.0/docs/data-sources/region) | data source |
 | [aws_route53_zone.selected](https://registry.terraform.io/providers/hashicorp/aws/6.43.0/docs/data-sources/route53_zone) | data source |
 | [aws_ssm_parameter.vault_pki_intermediate_ca_csr](https://registry.terraform.io/providers/hashicorp/aws/6.43.0/docs/data-sources/ssm_parameter) | data source |

--- a/examples/self-signed-tls/defaults.auto.tfvars.example
+++ b/examples/self-signed-tls/defaults.auto.tfvars.example
@@ -1,4 +1,2 @@
 vault_enterprise_license = "LICENSE"
 route53_zone_name        = "example.com"
-ami_owner                = "099720109477"
-ami_name                 = "ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260503"

--- a/examples/self-signed-tls/main.tf
+++ b/examples/self-signed-tls/main.tf
@@ -2,21 +2,10 @@ data "aws_route53_zone" "selected" {
   name = var.route53_zone_name
 }
 
-data "aws_ami" "selected" {
-  most_recent = true
-  owners      = [var.ami_owner]
-
-  filter {
-    name   = "name"
-    values = [var.ami_name]
-  }
-}
-
 module "vault" {
   # tflint-ignore: terraform_module_pinned_source
   source = "git::https://github.com/craigsloggett/terraform-aws-vault-enterprise"
 
   vault_enterprise_license = var.vault_enterprise_license
   route53_zone             = data.aws_route53_zone.selected
-  ami                      = data.aws_ami.selected
 }

--- a/examples/self-signed-tls/variables.tf
+++ b/examples/self-signed-tls/variables.tf
@@ -8,13 +8,3 @@ variable "route53_zone_name" {
   type        = string
   description = "Name of the Route 53 hosted zone for the Vault DNS record."
 }
-
-variable "ami_name" {
-  type        = string
-  description = "AMI name filter for the EC2 AMI data source."
-}
-
-variable "ami_owner" {
-  type        = string
-  description = "AWS account ID that owns the AMI."
-}

--- a/main.tf
+++ b/main.tf
@@ -8,5 +8,15 @@ data "aws_availability_zones" "available" {
 
 data "aws_vpc" "existing" {
   count = var.vpc.existing != null ? 1 : 0
-  id    = var.vpc.existing.vpc_id
+
+  id = var.vpc.existing.vpc_id
+}
+
+data "aws_ami" "selected" {
+  owners = var.ami.owners
+
+  filter {
+    name   = "name"
+    values = [var.ami.name]
+  }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -20,7 +20,7 @@ output "vault_cluster_autoscaling_group_name" {
 
 output "ami_name" {
   description = "Name of the AMI used for EC2 instances."
-  value       = var.ami.name
+  value       = data.aws_ami.selected.name
 }
 
 output "vault_snapshot_aws_s3_bucket_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -6,10 +6,11 @@ variable "vault_enterprise_license" {
 
 variable "ami" {
   type = object({
-    id   = string
-    name = string
+    owners = optional(list(string), ["amazon"])
+    name   = optional(string, "ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-amd64-server-20260503")
   })
 
+  default     = {}
   description = "AMI for EC2 instances. Must be Ubuntu or Debian-based. Accepts the result of an `aws_ami` data source directly."
 }
 


### PR DESCRIPTION
This pull request drops the `var.ami` variable from required to optional and provides the Amazon owned Ubuntu image as the default value.